### PR TITLE
Changes to NativeContext

### DIFF
--- a/symbolic-base/src/ZkFold/Base/Data/Empty.hs
+++ b/symbolic-base/src/ZkFold/Base/Data/Empty.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE TypeOperators #-}
+
+module ZkFold.Base.Data.Empty where
+
+import           Data.Function    (const, ($))
+import           Data.Functor.Rep (Representable (..))
+import           GHC.Generics     (U1 (..), (:*:) (..), (:.:) (..))
+
+class Empty f where
+  empty :: f a
+
+instance Empty U1 where
+  empty = U1
+
+instance (Empty f, Empty g) => Empty (f :*: g) where
+  empty = empty :*: empty
+
+instance (Representable f, Empty g) => Empty (f :.: g) where
+  empty = Comp1 $ tabulate (const empty)

--- a/symbolic-base/src/ZkFold/Base/Protocol/IVC/AccumulatorScheme.hs
+++ b/symbolic-base/src/ZkFold/Base/Protocol/IVC/AccumulatorScheme.hs
@@ -9,7 +9,7 @@ module ZkFold.Base.Protocol.IVC.AccumulatorScheme where
 import           Control.Lens                               ((^.))
 import           Data.Constraint                            (withDict)
 import           Data.Constraint.Nat                        (plusMinusInverse1)
-import           Data.Functor.Rep                           (Representable (..))
+import           Data.Functor.Rep                           (Representable (..), mzipWithRep)
 import           Data.Zip                                   (Zip (..))
 import           GHC.IsList                                 (IsList (..))
 import           Prelude                                    (Foldable, Ord, fmap, ($), (.), (<$>))
@@ -68,7 +68,6 @@ accumulatorScheme :: forall algo d k a i p c .
     , KnownNat (d-1)
     , KnownNat (d+1)
     , Representable i
-    , Zip i
     , Ord (Rep i)
     , Foldable i
     , Foldable c
@@ -98,7 +97,7 @@ accumulatorScheme phi =
 
             -- X * pi + pi' as a list of univariate polynomials
             polyPi :: i (PU.PolyVec f (d+1))
-            polyPi = zipWith PU.polyVecLinear pubi (acc^.x^.pi)
+            polyPi = mzipWithRep PU.polyVecLinear pubi (acc^.x^.pi)
 
             -- X * mi + mi'
             polyW :: Vector k [PU.PolyVec f (d+1)]
@@ -131,7 +130,7 @@ accumulatorScheme phi =
 
             -- Fig. 3, steps 5, 6
             mu'   = alpha + acc^.x^.mu
-            pi''  = zipWith (+) (fmap (* alpha) pubi) (acc^.x^.pi)
+            pi''  = mzipWithRep (+) (fmap (* alpha) pubi) (acc^.x^.pi)
             ri''  = scale alpha r_i  + acc^.x^.r
             ci''  = scale alpha pi_x + acc^.x^.c
             m_i'' = zipWith (+) (scale alpha pi_w) (acc^.w)
@@ -166,7 +165,7 @@ accumulatorScheme phi =
 
             -- Fig. 4, steps 3-4
             mu'  = alpha + acc^.mu
-            pi'' = zipWith (+) (fmap (* alpha) pubi) (acc^.pi)
+            pi'' = mzipWithRep (+) (fmap (* alpha) pubi) (acc^.pi)
             ri'' = zipWith (+) (scale alpha r_i)     (acc^.r)
             ci'' = zipWith (+) (scale alpha pi_x)    (acc^.c)
 

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Class.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Class.hs
@@ -9,6 +9,7 @@ module ZkFold.Symbolic.Data.Class (
         SymbolicData (..),
         SymbolicOutput,
         GSymbolicData (..),
+        restore0,
     ) where
 
 import           Control.Applicative              ((<*>))
@@ -31,6 +32,7 @@ import qualified GHC.Generics                     as G
 import           ZkFold.Base.Algebra.Basic.Number (KnownNat)
 import           ZkFold.Base.Control.HApplicative (HApplicative, hliftA2, hpure)
 import           ZkFold.Base.Data.ByteString      (Binary1)
+import           ZkFold.Base.Data.Empty           (Empty (..))
 import           ZkFold.Base.Data.HFunctor        (hmap)
 import           ZkFold.Base.Data.Orphans         ()
 import           ZkFold.Base.Data.Package         (pack)
@@ -100,6 +102,11 @@ class
     restore f = G.to (grestore f)
 
 type SymbolicOutput x = (SymbolicData x, Support x ~ Proxy (Context x))
+
+restore0 ::
+  (SymbolicData x, Empty (Payload x)) =>
+  (Support x -> Context x (Layout x)) -> x
+restore0 f = restore (\x -> (f x, empty))
 
 instance (Symbolic c, LayoutFunctor f) => SymbolicData (c f) where
     type Context (c f) = c

--- a/symbolic-base/symbolic-base.cabal
+++ b/symbolic-base/symbolic-base.cabal
@@ -113,6 +113,7 @@ library
       ZkFold.Base.Algorithm.ReedSolomon
       ZkFold.Base.Control.HApplicative
       ZkFold.Base.Data.ByteString
+      ZkFold.Base.Data.Empty
       ZkFold.Base.Data.HFunctor
       ZkFold.Base.Data.List.Infinite
       ZkFold.Base.Data.Matrix


### PR DESCRIPTION
A concept on how to make cyclefold work
Doesn't compile!
Key idea: we need two Symbolic point types from curve cycle where all fields are FFA.
Thanks to how our FFA works, in case its order matches the base field of a circuit, it is represented with FieldElement internally so is very cheap.
So by choosing appropriate contexts for these point types we obtain datatypes needed for CycleFold.
To compute layout, you can use `Interpreter a` context.
To compute FFA without storing constraints, we might need a `FFAW` newtype similar to `FieldElementW` (or wait for Symbolic refactor and play with contexts).
To convert values, you can use `ToConstant (FFA p r (Interpreter a))` instance.