### PR TITLE
A quickfix for PlonkUp test failure

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,8 @@
     "haskell.manageHLS": "GHCup",
     "haskell.toolchain": {
       "hls": "2.9.0.1",
-      "cabal": "3.10.3.0",
-      "ghc": "9.6.6",
+      "cabal": "3.14.1.1",
+      "ghc": "9.12.1",
       "stack": null
     }, 
     "haskell.formattingProvider": "stylish-haskell"

--- a/symbolic-base/src/ZkFold/Prelude.hs
+++ b/symbolic-base/src/ZkFold/Prelude.hs
@@ -78,5 +78,6 @@ assert statement obj x = if statement then x else error $ show obj
 chooseNatural :: (Natural, Natural) -> Gen Natural
 chooseNatural (lo, hi) = integerToNatural <$> chooseInteger (fromIntegral lo, fromIntegral hi)
 
-genSubset :: Natural -> [a] -> Gen [a]
-genSubset l as = take l <$> shuffle as
+-- | Choose a list of length `l` from a list allowing repetitions.
+chooseFromList :: Natural -> [a] -> Gen [a]
+chooseFromList l as = take l <$> shuffle (concatMap (replicate l) as)

--- a/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
@@ -22,7 +22,7 @@ import           Test.QuickCheck                                     (Arbitrary 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Number
 import           ZkFold.Base.Data.Vector                             (Vector, unsafeToVector)
-import           ZkFold.Prelude                                      (genSubset, length)
+import           ZkFold.Prelude                                      (chooseFromList, length)
 import           ZkFold.Symbolic.Class
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Internal
 import           ZkFold.Symbolic.Compiler.ArithmeticCircuit.Lookup   (LookupType)
@@ -64,7 +64,7 @@ instance
   ) => Arbitrary (ArithmeticCircuit a p i (Vector l)) where
     arbitrary = do
         ac <- arbitrary @(ArithmeticCircuit a p i Par1)
-        o  <- unsafeToVector <$> genSubset (value @l) (getAllVars ac)
+        o  <- unsafeToVector <$> chooseFromList (value @l) (getAllVars ac)
         return ac {acOutput = toVar <$> o}
 
 arbitrary' ::


### PR DESCRIPTION
The problem was in the `genSubSet` function. Actually, we needed to generate a vector of a fixed size. This change fixes the current test, although we might want to handle "no variables" case in the future.