### PR TITLE
Added higher-order functor classes

### DIFF
--- a/symbolic-base/src/ZkFold/Base/Data/HFunctor/Classes.hs
+++ b/symbolic-base/src/ZkFold/Base/Data/HFunctor/Classes.hs
@@ -1,7 +1,23 @@
+{-# LANGUAGE QuantifiedConstraints #-}
+
 module ZkFold.Base.Data.HFunctor.Classes where
 
+import           Control.DeepSeq      (NFData, NFData1)
+import           Data.Bool            (Bool)
+import           Data.Eq              (Eq)
+import           Data.Functor.Classes (Eq1, Show1)
+import           Data.Int             (Int)
+import           Text.Show            (Show, ShowS)
+
 class (forall f. Eq1 f => Eq (c f)) => HEq c where
+  hliftEq ::
+    (forall a. (a -> a -> Bool) -> f a -> f a -> Bool) -> c f -> c f -> Bool
 
 class (forall f. Show1 f => Show (c f)) => HShow c where
+  hliftShowsPrec ::
+    (forall a. (Int -> a -> ShowS) -> ([a] -> ShowS) -> Int -> f a -> ShowS) ->
+    (forall a. (Int -> a -> ShowS) -> ([a] -> ShowS) -> [f a] -> ShowS) ->
+    Int -> c f -> ShowS
 
 class (forall f. NFData1 f => NFData (c f)) => HNFData c where
+  hliftRnf :: (forall a. (a -> ()) -> f a -> ()) -> c f -> ()

--- a/symbolic-base/src/ZkFold/Base/Data/HFunctor/Classes.hs
+++ b/symbolic-base/src/ZkFold/Base/Data/HFunctor/Classes.hs
@@ -1,0 +1,7 @@
+module ZkFold.Base.Data.HFunctor.Classes where
+
+class (forall f. Eq1 f => Eq (c f)) => HEq c where
+
+class (forall f. Show1 f => Show (c f)) => HShow c where
+
+class (forall f. NFData1 f => NFData (c f)) => HNFData c where

--- a/symbolic-base/src/ZkFold/Base/Data/Vector.hs
+++ b/symbolic-base/src/ZkFold/Base/Data/Vector.hs
@@ -11,7 +11,7 @@ import           Data.Aeson                       (FromJSON (..), ToJSON (..))
 import           Data.Constraint.Nat              (Max)
 import           Data.Distributive                (Distributive (..))
 import           Data.Foldable                    (fold)
-import           Data.Functor.Classes             (Show1)
+import           Data.Functor.Classes             (Show1, Eq1)
 import           Data.Functor.Rep                 (Representable (..), collectRep, distributeRep, mzipRep, pureRep)
 import           Data.These                       (These (..))
 import qualified Data.Vector                      as V
@@ -33,7 +33,7 @@ import           ZkFold.Base.Data.ByteString      (Binary (..))
 import           ZkFold.Prelude                   (length)
 
 newtype Vector (size :: Natural) a = Vector {toV :: V.Vector a}
-    deriving (Show, Show1, Eq, Functor, Foldable, Traversable, Generic, NFData, NFData1, Ord)
+    deriving (Show, Show1, Eq, Eq1, Functor, Foldable, Traversable, Generic, NFData, NFData1, Ord)
     deriving newtype (FromJSON, ToJSON)
 
 -- helper

--- a/symbolic-base/src/ZkFold/Symbolic/Algorithms/RSA.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Algorithms/RSA.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE NoStarIsType         #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -20,14 +21,14 @@ import           Prelude                              (($))
 import qualified Prelude                              as P
 
 import           ZkFold.Base.Algebra.Basic.Number
-import           ZkFold.Base.Data.Vector              (Vector)
+import           ZkFold.Base.Data.HFunctor.Classes    (HEq, HNFData, HShow)
 import           ZkFold.Symbolic.Algorithms.Hash.SHA2 (SHA2, sha2, sha2Var)
 import           ZkFold.Symbolic.Class
 import           ZkFold.Symbolic.Data.Bool            (Bool, (&&))
 import           ZkFold.Symbolic.Data.ByteString      (ByteString)
 import           ZkFold.Symbolic.Data.Class
 import           ZkFold.Symbolic.Data.Combinators     (Ceil, GetRegisterSize, Iso (..), KnownRegisters,
-                                                       NumberOfRegisters, RegisterSize (..), Resize (..))
+                                                       RegisterSize (..), Resize (..))
 import           ZkFold.Symbolic.Data.Eq
 import           ZkFold.Symbolic.Data.Input           (SymbolicInput, isValid)
 import           ZkFold.Symbolic.Data.UInt            (OrdWord, UInt, expMod)
@@ -42,12 +43,9 @@ data PrivateKey keyLen ctx
         }
 
 deriving instance Generic (PrivateKey keyLen context)
-deriving instance (NFData (context (Vector (NumberOfRegisters (BaseField context) keyLen 'Auto)))) => NFData (PrivateKey keyLen context)
-deriving instance (P.Eq (context (Vector (NumberOfRegisters (BaseField context) keyLen 'Auto))))   => P.Eq   (PrivateKey keyLen context)
-deriving instance
-    ( P.Show (BaseField context)
-    , P.Show (context (Vector (NumberOfRegisters (BaseField context) keyLen 'Auto)))
-    ) => P.Show (PrivateKey keyLen context)
+deriving instance HNFData context => NFData (PrivateKey keyLen context)
+deriving instance HEq context => P.Eq (PrivateKey keyLen context)
+deriving instance HShow context => P.Show (PrivateKey keyLen context)
 
 deriving instance (Symbolic ctx, KnownRegisters ctx keyLen 'Auto) => SymbolicData (PrivateKey keyLen ctx)
 
@@ -67,19 +65,9 @@ data PublicKey keyLen ctx
         }
 
 deriving instance Generic (PublicKey keyLen context)
-deriving instance
-    ( NFData (context (Vector (NumberOfRegisters (BaseField context) keyLen 'Auto)))
-    , NFData (context (Vector (NumberOfRegisters (BaseField context) PubExponentSize 'Auto)))
-    ) =>  NFData  (PublicKey keyLen context)
-deriving instance
-    ( P.Eq (context (Vector (NumberOfRegisters (BaseField context) keyLen 'Auto)))
-    , P.Eq (context (Vector (NumberOfRegisters (BaseField context) PubExponentSize 'Auto)))
-    ) =>  P.Eq    (PublicKey keyLen context)
-deriving instance
-    ( P.Show (context (Vector (NumberOfRegisters (BaseField context) keyLen 'Auto)))
-    , P.Show (context (Vector (NumberOfRegisters (BaseField context) PubExponentSize 'Auto)))
-    , P.Show (BaseField context)
-    ) =>  P.Show  (PublicKey keyLen context)
+deriving instance HNFData context => NFData (PublicKey keyLen context)
+deriving instance HEq context => P.Eq (PublicKey keyLen context)
+deriving instance HShow context => P.Show (PublicKey keyLen context)
 
 deriving instance
     ( Symbolic ctx
@@ -102,9 +90,6 @@ type RSA keyLen msgLen ctx =
    , KnownRegisters ctx keyLen 'Auto
    , KnownRegisters ctx (2 * keyLen) 'Auto
    , KnownNat (Ceil (GetRegisterSize (BaseField ctx) (2 * keyLen) 'Auto) OrdWord)
-   , NFData (ctx (Vector keyLen))
-   , NFData (ctx (Vector (NumberOfRegisters (BaseField ctx) keyLen 'Auto)))
-   , NFData (ctx (Vector (NumberOfRegisters (BaseField ctx) (2 * keyLen) 'Auto)))
    )
 
 sign

--- a/symbolic-base/src/ZkFold/Symbolic/Class.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Class.hs
@@ -20,6 +20,7 @@ import           ZkFold.Base.Control.HApplicative (HApplicative (hpair, hunit))
 import           ZkFold.Base.Data.Package         (Package (pack))
 import           ZkFold.Base.Data.Product         (uncurryP)
 import           ZkFold.Symbolic.MonadCircuit
+import ZkFold.Base.Data.HFunctor.Classes (HNFData)
 
 -- | Field of residues with decidable equality and ordering
 -- is called an ``arithmetic'' field.
@@ -45,8 +46,9 @@ type family FunBody (fs :: [Type -> Type]) (g :: Type -> Type) (i :: Type) (m ::
 
 -- | A Symbolic DSL for performant pure computations with arithmetic circuits.
 -- @c@ is a generic context in which computations are performed.
-class ( HApplicative c, Package c, Arithmetic (BaseField c)
-      , ResidueField (WitnessField c)) => Symbolic c where
+class ( HApplicative c, Package c, HNFData c
+      , Arithmetic (BaseField c), ResidueField (WitnessField c)
+      ) => Symbolic c where
     -- | Base algebraic field over which computations are performed.
     type BaseField c :: Type
     -- | Type of witnesses usable inside circuit construction

--- a/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Instance.hs
@@ -1,5 +1,6 @@
-{-# OPTIONS_GHC -Wno-orphans     #-}
 {-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans     #-}
 
 module ZkFold.Symbolic.Compiler.ArithmeticCircuit.Instance where
 
@@ -11,8 +12,7 @@ import           Data.Functor.Rep                                    (Representa
 import           Data.Map                                            hiding (drop, foldl, foldl', foldr, map, null,
                                                                       splitAt, take, toList)
 import           GHC.Generics                                        (Par1 (..))
-import           Prelude                                             (Show, head, mempty, pure, return, show, ($), (++),
-                                                                      (.), (<$>), (<))
+import           Prelude                                             (head, mempty, pure, return, ($), (.), (<$>), (<))
 import qualified Prelude                                             as Haskell
 import           Test.QuickCheck                                     (Arbitrary (arbitrary), Gen, elements)
 
@@ -96,13 +96,6 @@ createRangeConstraint (FieldElement x) a = FieldElement $ fromCircuitF x (\ (Par
       v' <- newAssigned (Haskell.const zero)
       rangeConstraint v' b
       return v
-
--- TODO: make it more readable
-instance (Show a, Show (o (Var a i)), Show (Var a i), Show (Rep i), Haskell.Ord (Rep i)) => Show (ArithmeticCircuit a i o) where
-    show r = "ArithmeticCircuit { acSystem = " ++ show (acSystem r)
-                          ++ "\n, acRange = " ++ show (acLookup r)
-                          ++ "\n, acOutput = " ++ show (acOutput r)
-                          ++ " }"
 
 -- TODO: add witness generation info to the JSON object
 instance (ToJSON a, ToJSON (o (Var a i)), ToJSONKey a, FromJSONKey (Var a i), ToJSON (Rep i), ToJSON (LookupType a), ToJSONKey (LookupType a)) => ToJSON (ArithmeticCircuit a i o) where

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Bool.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Bool.hs
@@ -25,6 +25,7 @@ import           ZkFold.Symbolic.Class
 import           ZkFold.Symbolic.Data.Class      (SymbolicData)
 import           ZkFold.Symbolic.Interpreter     (Interpreter (..))
 import           ZkFold.Symbolic.MonadCircuit    (newAssigned)
+import ZkFold.Base.Data.HFunctor.Classes (HShow, HEq, HNFData)
 
 class BoolType b where
     true  :: b
@@ -58,9 +59,9 @@ instance BoolType Haskell.Bool where
 newtype Bool c = Bool (c Par1)
     deriving (Generic)
 
-deriving instance NFData (c Par1) => NFData (Bool c)
-deriving instance Eq (c Par1) => Eq (Bool c)
-deriving instance Show (c Par1) => Show (Bool c)
+deriving instance HNFData c => NFData (Bool c)
+deriving instance HEq c => Eq (Bool c)
+deriving instance HShow c => Show (Bool c)
 
 instance Symbolic c => SymbolicData (Bool c)
 

--- a/symbolic-base/src/ZkFold/Symbolic/Data/ByteString.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/ByteString.hs
@@ -67,6 +67,7 @@ import           ZkFold.Symbolic.Data.FieldElement (FieldElement)
 import           ZkFold.Symbolic.Data.Input        (SymbolicInput, isValid)
 import           ZkFold.Symbolic.Interpreter       (Interpreter (..))
 import           ZkFold.Symbolic.MonadCircuit      (ClosedPoly, newAssigned)
+import ZkFold.Base.Data.HFunctor.Classes (HNFData, HEq, HShow)
 
 -- | A ByteString which stores @n@ bits and uses elements of @a@ as registers, one element per register.
 -- Bit layout is Big-endian.
@@ -74,9 +75,9 @@ import           ZkFold.Symbolic.MonadCircuit      (ClosedPoly, newAssigned)
 newtype ByteString (n :: Natural) (context :: (Type -> Type) -> Type) = ByteString (context (Vector n))
     deriving (Generic)
 
-deriving stock instance Haskell.Show (c (Vector n)) => Haskell.Show (ByteString n c)
-deriving stock instance Haskell.Eq (c (Vector n)) => Haskell.Eq (ByteString n c)
-deriving anyclass instance NFData (c (Vector n)) => NFData (ByteString n c)
+deriving stock instance HShow c => Haskell.Show (ByteString n c)
+deriving stock instance HEq c => Haskell.Eq (ByteString n c)
+deriving anyclass instance HNFData c => NFData (ByteString n c)
 deriving newtype instance (KnownNat n, Symbolic c) => SymbolicData (ByteString n c)
 deriving newtype instance (Symbolic c, KnownNat n) => Eq (ByteString n c)
 deriving newtype instance (Symbolic c, KnownNat n) => Conditional (Bool c) (ByteString n c)

--- a/symbolic-base/src/ZkFold/Symbolic/Data/FFA.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/FFA.hs
@@ -41,6 +41,7 @@ import           ZkFold.Symbolic.Data.Ord          (Ord (..))
 import           ZkFold.Symbolic.Data.UInt         (OrdWord, UInt (..), natural, register, toNative)
 import           ZkFold.Symbolic.Interpreter       (Interpreter (..))
 import           ZkFold.Symbolic.MonadCircuit      (MonadCircuit (..), ResidueField (..), Witness (..))
+import ZkFold.Base.Data.HFunctor.Classes (HNFData, HShow)
 
 type family FFAUIntSize (p :: Natural) (q :: Natural) :: Natural where
   FFAUIntSize p p = 0
@@ -80,11 +81,11 @@ instance (Symbolic c, KnownFFA p r c) => SymbolicInput (FFA p r c) where
     if isNative @p @r @c
       then true
       else isValid ux && toUInt @(FFAMaxBits p c) ffa < fromConstant (value @p)
-instance (NFData (FieldElement c), NFData (UIntFFA p r c)) => NFData (FFA p r c)
+
+instance HNFData c => NFData (FFA p r c)
+deriving stock instance HShow c => Show (FFA p r c)
 instance (Symbolic c, KnownFFA p r c, b ~ Bool c) => Conditional b (FFA p r c)
 instance (Symbolic c, KnownFFA p r c) => Eq (FFA p r c)
-deriving stock instance (Show (FieldElement c), Show (UIntFFA p r c)) =>
-  Show (FFA p r c)
 
 bezoutFFA ::
   forall p a. (KnownNat p, KnownNat (FFAUIntSize p (Order a))) => Integer

--- a/symbolic-base/src/ZkFold/Symbolic/Data/FieldElement.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/FieldElement.hs
@@ -27,24 +27,18 @@ import           ZkFold.Symbolic.Data.Input
 import           ZkFold.Symbolic.Data.Ord
 import           ZkFold.Symbolic.Interpreter      (Interpreter (..))
 import           ZkFold.Symbolic.MonadCircuit     (newAssigned)
+import ZkFold.Base.Data.HFunctor.Classes (HShow, HEq, HNFData)
 
 newtype FieldElement c = FieldElement { fromFieldElement :: c Par1 }
     deriving Generic
 
-deriving stock instance Haskell.Show (c Par1) => Haskell.Show (FieldElement c)
-
-deriving stock instance Haskell.Eq (c Par1) => Haskell.Eq (FieldElement c)
-
-deriving stock instance Haskell.Ord (c Par1) => Haskell.Ord (FieldElement c)
-
-deriving newtype instance NFData (c Par1) => NFData (FieldElement c)
-
+deriving stock instance HShow c => Haskell.Show (FieldElement c)
+deriving stock instance HEq c => Haskell.Eq (FieldElement c)
+deriving stock instance (HEq c, Haskell.Ord (c Par1)) => Haskell.Ord (FieldElement c)
+deriving newtype instance HNFData c => NFData (FieldElement c)
 deriving newtype instance Symbolic c => SymbolicData (FieldElement c)
-
 deriving newtype instance Symbolic c => Conditional (Bool c) (FieldElement c)
-
 deriving newtype instance Symbolic c => Eq (FieldElement c)
-
 deriving newtype instance Symbolic c => Ord (FieldElement c)
 
 instance {-# INCOHERENT #-} (Symbolic c, FromConstant k (BaseField c)) => FromConstant k (FieldElement c) where

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Int.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Int.hs
@@ -16,7 +16,7 @@ import           Test.QuickCheck                  (Arbitrary (..))
 
 import           ZkFold.Base.Algebra.Basic.Class  hiding (Euclidean (..))
 import           ZkFold.Base.Algebra.Basic.Number
-import           ZkFold.Base.Data.Vector          (Vector (..), fromVector)
+import           ZkFold.Base.Data.Vector          (fromVector)
 import           ZkFold.Symbolic.Class
 import           ZkFold.Symbolic.Data.Bool
 import           ZkFold.Symbolic.Data.Class       (SymbolicData)
@@ -26,15 +26,15 @@ import           ZkFold.Symbolic.Data.Eq
 import           ZkFold.Symbolic.Data.Ord
 import           ZkFold.Symbolic.Data.UInt
 import           ZkFold.Symbolic.Interpreter      (Interpreter (..))
+import ZkFold.Base.Data.HFunctor.Classes (HShow, HEq, HNFData)
 
 
 newtype Int (n :: Natural) (r :: RegisterSize) (c :: (Type -> Type) -> Type) = Int { uint :: UInt n r c}
 
 deriving instance Generic (Int n r c)
-deriving instance (NFData (c (Vector (NumberOfRegisters (BaseField c) n r)))) => NFData (Int n r c)
-deriving instance (Haskell.Eq (c (Vector (NumberOfRegisters (BaseField c) n r)))) => Haskell.Eq (Int n r c)
-deriving instance (Haskell.Show (BaseField c), Haskell.Show (c (Vector (NumberOfRegisters (BaseField c) n r))))
-    => Haskell.Show (Int n r c)
+deriving instance HNFData c => NFData (Int n r c)
+deriving instance HEq c => Haskell.Eq (Int n r c)
+deriving instance HShow c => Haskell.Show (Int n r c)
 deriving instance (KnownRegisters c n r, Symbolic c) => SymbolicData (Int n r c)
 deriving instance (KnownRegisters c n r, Symbolic c) => Conditional (Bool c) (Int n r c)
 deriving instance (KnownRegisters c n r, Symbolic c) => Eq (Int n r c)

--- a/symbolic-base/src/ZkFold/Symbolic/Data/JWT/Google.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/JWT/Google.hs
@@ -4,7 +4,6 @@
 
 module ZkFold.Symbolic.Data.JWT.Google (GooglePayload (..)) where
 
-import           Control.DeepSeq                    (NFData)
 import           Data.Aeson                         (FromJSON (..), genericParseJSON)
 import qualified Data.Aeson                         as JSON
 import           Data.Aeson.Casing                  (aesonPrefix, snakeCase)
@@ -12,12 +11,11 @@ import           Data.Maybe                         (fromMaybe)
 import           Data.Scientific                    (toBoundedInteger)
 import qualified Data.Text                          as T
 import           Generic.Random                     (genericArbitrary, uniform)
-import           GHC.Generics                       (Generic, Par1 (..))
+import           GHC.Generics                       (Generic)
 import           Prelude                            (fmap, type (~), ($), (.))
 import qualified Prelude                            as P
 import           Test.QuickCheck                    (Arbitrary (..))
 
-import qualified ZkFold.Base.Data.Vector            as V
 import qualified ZkFold.Symbolic.Algorithms.RSA     as RSA
 import           ZkFold.Symbolic.Class
 import           ZkFold.Symbolic.Data.Bool
@@ -29,6 +27,7 @@ import           ZkFold.Symbolic.Data.JWT
 import           ZkFold.Symbolic.Data.JWT.RS256
 import qualified ZkFold.Symbolic.Data.VarByteString as VB
 import           ZkFold.Symbolic.Data.VarByteString (VarByteString (..), (@+))
+import ZkFold.Base.Data.HFunctor.Classes (HEq, HShow)
 
 
 -- | Json Web Token payload with information about the issuer, bearer and TTL
@@ -66,22 +65,8 @@ data GooglePayload ctx
         }
     deriving Generic
 
-deriving instance
-    ( P.Eq (ctx (V.Vector 40))
-    , P.Eq (ctx (V.Vector 80))
-    , P.Eq (ctx (V.Vector 256))
-    , P.Eq (ctx (V.Vector 512))
-    , P.Eq (ctx (V.Vector 1024))
-    , P.Eq (ctx Par1)
-    ) => P.Eq (GooglePayload ctx)
-deriving instance
-    ( P.Show (ctx (V.Vector 40))
-    , P.Show (ctx (V.Vector 80))
-    , P.Show (ctx (V.Vector 256))
-    , P.Show (ctx (V.Vector 512))
-    , P.Show (ctx (V.Vector 1024))
-    , P.Show (ctx Par1)
-    ) => P.Show (GooglePayload ctx)
+deriving instance HEq ctx => P.Eq (GooglePayload ctx)
+deriving instance HShow ctx => P.Show (GooglePayload ctx)
 deriving instance Symbolic ctx => SymbolicData (GooglePayload ctx)
 deriving instance Symbolic ctx => SymbolicInput (GooglePayload ctx)
 instance Symbolic ctx => Arbitrary (GooglePayload ctx) where
@@ -119,11 +104,7 @@ instance (Symbolic ctx, Context (GooglePayload ctx) ~ ctx) => IsSymbolicJSON (Go
         `VB.append` (fromType @",\"exp\":")   @+ plExp
         `VB.append` (fromType @"}")
 
-instance
-  ( Symbolic ctx
-  , NFData (ctx (V.Vector 8))
-  , NFData (ctx (V.Vector 9456))
-  ) => IsBits (GooglePayload ctx) where
+instance Symbolic ctx => IsBits (GooglePayload ctx) where
     type BitCount (GooglePayload ctx) = 9456
     toBits = toAsciiBits
 

--- a/symbolic-base/src/ZkFold/Symbolic/Data/JWT/RS256.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/JWT/RS256.hs
@@ -15,6 +15,7 @@ import qualified Prelude                            as P
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Number   (Natural)
+import           ZkFold.Base.Data.HFunctor.Classes  (HEq, HNFData, HShow)
 import           ZkFold.Symbolic.Algorithms.RSA
 import           ZkFold.Symbolic.Class
 import           ZkFold.Symbolic.Data.ByteString    (ByteString)
@@ -32,18 +33,9 @@ data Certificate ctx
         }
     deriving Generic
 
-deriving instance
-    ( P.Eq (PublicKey 2048 ctx)
-    , P.Eq (VarByteString 320 ctx)
-    ) => P.Eq (Certificate ctx)
-deriving instance
-    ( P.Show (PublicKey 2048 ctx)
-    , P.Show (VarByteString 320 ctx)
-    ) => P.Show (Certificate ctx)
-deriving instance
-    ( NFData (PublicKey 2048 ctx)
-    , NFData (VarByteString 320 ctx)
-    ) => NFData (Certificate ctx)
+deriving instance HEq ctx => P.Eq (Certificate ctx)
+deriving instance HShow ctx => P.Show (Certificate ctx)
+deriving instance HNFData ctx => NFData (Certificate ctx)
 instance
     ( SymbolicData (PublicKey 2048 ctx)
     , Symbolic ctx
@@ -69,8 +61,7 @@ instance Symbolic ctx => FromJSON (Certificate ctx) where
         pure $ Certificate kidBs pubKey
 
 bsToNat :: BS.ByteString -> Natural
-bsToNat bs = BS.foldl' (\i b -> (i `B.shiftL` 8) + P.fromIntegral b) 0 bs
-
+bsToNat = BS.foldl' (\i b -> (i `B.shiftL` 8) + P.fromIntegral b) 0
 
 -- | RSA Private key with Key ID
 --
@@ -81,18 +72,9 @@ data SigningKey ctx
         }
     deriving Generic
 
-deriving instance
-    ( P.Eq (PrivateKey 2048 ctx)
-    , P.Eq (VarByteString 320 ctx)
-    ) => P.Eq (SigningKey ctx)
-deriving instance
-    ( P.Show (PrivateKey 2048 ctx)
-    , P.Show (VarByteString 320 ctx)
-    ) => P.Show (SigningKey ctx)
-deriving instance
-    ( NFData (PrivateKey 2048 ctx)
-    , NFData (VarByteString 320 ctx)
-    ) => NFData (SigningKey ctx)
+deriving instance HEq ctx => P.Eq (SigningKey ctx)
+deriving instance HShow ctx => P.Show (SigningKey ctx)
+deriving instance HNFData ctx => NFData (SigningKey ctx)
 instance
     ( SymbolicData (PrivateKey 2048 ctx)
     , Symbolic ctx

--- a/symbolic-base/src/ZkFold/Symbolic/Data/JWT/Twitch.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/JWT/Twitch.hs
@@ -4,16 +4,15 @@
 
 module ZkFold.Symbolic.Data.JWT.Twitch (TwitchPayload (..)) where
 
-import           Control.DeepSeq                    (NFData)
 import           Data.Aeson                         (FromJSON (..), genericParseJSON)
 import           Data.Aeson.Casing                  (aesonPrefix, snakeCase)
 import           Generic.Random                     (genericArbitrary, uniform)
-import           GHC.Generics                       (Generic, Par1 (..))
+import           GHC.Generics                       (Generic)
 import           Prelude                            (type (~), (.))
 import qualified Prelude                            as P
 import           Test.QuickCheck                    (Arbitrary (..))
 
-import qualified ZkFold.Base.Data.Vector            as V
+import           ZkFold.Base.Data.HFunctor.Classes  (HEq, HShow)
 import           ZkFold.Symbolic.Algorithms.RSA     as RSA
 import           ZkFold.Symbolic.Class
 import           ZkFold.Symbolic.Data.Bool
@@ -58,14 +57,8 @@ data PubSubPerms ctx =
         }
     deriving Generic
 
-deriving instance
-    ( P.Eq (ctx (V.Vector 2048))
-    , P.Eq (ctx Par1)
-    ) => P.Eq (PubSubPerms ctx)
-deriving instance
-    ( P.Show (ctx (V.Vector 2048))
-    , P.Show (ctx Par1)
-    ) => P.Show (PubSubPerms ctx)
+deriving instance HEq ctx => P.Eq (PubSubPerms ctx)
+deriving instance HShow ctx => P.Show (PubSubPerms ctx)
 deriving instance Symbolic ctx => SymbolicData (PubSubPerms ctx)
 deriving instance Symbolic ctx => SymbolicInput (PubSubPerms ctx)
 instance Symbolic ctx => Arbitrary (PubSubPerms ctx) where
@@ -81,23 +74,8 @@ instance (Symbolic ctx, Context (PubSubPerms ctx) ~ ctx) => IsSymbolicJSON (PubS
 instance Symbolic ctx => FromJSON (PubSubPerms ctx) where
     parseJSON = genericParseJSON (aesonPrefix snakeCase) . stringify
 
-deriving instance
-    ( P.Eq (ctx (V.Vector 40))
-    , P.Eq (ctx (V.Vector 80))
-    , P.Eq (ctx (V.Vector 88))
-    , P.Eq (ctx (V.Vector 512))
-    , P.Eq (ctx (V.Vector 2048))
-    , P.Eq (ctx Par1)
-    ) => P.Eq (TwitchPayload ctx)
-
-deriving instance
-    ( P.Show (ctx (V.Vector 40))
-    , P.Show (ctx (V.Vector 80))
-    , P.Show (ctx (V.Vector 88))
-    , P.Show (ctx (V.Vector 512))
-    , P.Show (ctx (V.Vector 2048))
-    , P.Show (ctx Par1)
-    ) => P.Show (TwitchPayload ctx)
+deriving instance HEq ctx => P.Eq (TwitchPayload ctx)
+deriving instance HShow ctx => P.Show (TwitchPayload ctx)
 deriving instance Symbolic ctx => SymbolicData (TwitchPayload ctx)
 deriving instance Symbolic ctx => SymbolicInput (TwitchPayload ctx)
 instance Symbolic ctx => Arbitrary (TwitchPayload ctx) where
@@ -118,11 +96,7 @@ instance (Symbolic ctx) => IsSymbolicJSON (TwitchPayload ctx) where
         `VB.append` (fromType @"\",\"user_id\":\"") @+ twUserId
         `VB.append` (fromType @"\"}")
 
-instance
-  ( Symbolic ctx
-  , NFData (ctx (V.Vector 8))
-  , NFData (ctx (V.Vector 9056))
-  ) => IsBits (TwitchPayload ctx) where
+instance Symbolic ctx => IsBits (TwitchPayload ctx) where
     type BitCount (TwitchPayload ctx) = 9056
     toBits = toAsciiBits
 

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Maybe.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Maybe.hs
@@ -7,13 +7,14 @@ module ZkFold.Symbolic.Data.Maybe (
     Maybe, maybe, just, nothing, fromMaybe, fromJust, isNothing, isJust, find
 ) where
 
-import           Data.Functor                     ((<$>))
-import           Data.Functor.Rep                 (pureRep)
-import           GHC.Generics                     (Generic, Par1 (..))
-import           Prelude                          (foldr, type (~), ($))
-import qualified Prelude                          as Haskell
+import           Data.Functor                      ((<$>))
+import           Data.Functor.Rep                  (pureRep)
+import           GHC.Generics                      (Generic)
+import           Prelude                           (foldr, type (~), ($))
+import qualified Prelude                           as Haskell
 
 import           ZkFold.Base.Algebra.Basic.Class
+import           ZkFold.Base.Data.HFunctor.Classes (HEq)
 import           ZkFold.Symbolic.Class
 import           ZkFold.Symbolic.Data.Bool
 import           ZkFold.Symbolic.Data.Class
@@ -28,8 +29,7 @@ data Maybe context x = Maybe { isJust :: Bool context, fromJust :: x }
     , Generic
     )
 
-deriving stock instance (Haskell.Eq (context Par1), Haskell.Eq x) => Haskell.Eq (Maybe context x)
-
+deriving stock instance (HEq c, Haskell.Eq x) => Haskell.Eq (Maybe c x)
 instance (SymbolicOutput x, Context x ~ c) => SymbolicData (Maybe c x) where
 instance (SymbolicOutput x, Context x ~ c, Conditional (Bool c) x) => Conditional (Bool c) (Maybe c x)
 instance (Context x ~ c, SymbolicEq x) => Eq (Maybe c x)

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Ord.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Ord.hs
@@ -29,6 +29,7 @@ import           ZkFold.Symbolic.Data.Combinators (expansion)
 import           ZkFold.Symbolic.Data.Conditional
 import           ZkFold.Symbolic.Data.Eq
 import           ZkFold.Symbolic.MonadCircuit     (newAssigned)
+import ZkFold.Base.Data.HFunctor.Classes (HNFData, HShow)
 
 class Monoid ordering => IsOrdering ordering where
   lt, eq, gt :: ordering
@@ -131,8 +132,8 @@ instance KnownNat n => Ord (Zp n) where
 
 newtype Ordering c = Ordering (c Par1)
   deriving (Generic)
-deriving instance NFData (c Par1) => NFData (Ordering c)
-deriving instance Show (c Par1) => Show (Ordering c)
+deriving instance HNFData c => NFData (Ordering c)
+deriving instance HShow c => Show (Ordering c)
 deriving newtype instance Symbolic c => Conditional (Bool c) (Ordering c)
 deriving newtype instance Symbolic c => Eq (Ordering c)
 instance Symbolic c => SymbolicData (Ordering c)

--- a/symbolic-base/src/ZkFold/Symbolic/Data/UInt.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/UInt.hs
@@ -72,15 +72,16 @@ import           ZkFold.Symbolic.Data.Ord
 import           ZkFold.Symbolic.Interpreter       (Interpreter (..))
 import           ZkFold.Symbolic.MonadCircuit      (MonadCircuit (..), ResidueField (..), Witness (..), constraint,
                                                     newAssigned, newRanged)
+import ZkFold.Base.Data.HFunctor.Classes (HShow, HEq, HNFData)
 
 
 -- TODO (Issue #18): hide this constructor
 newtype UInt (n :: Natural) (r :: RegisterSize) (context :: (Type -> Type) -> Type) = UInt (context (Vector (NumberOfRegisters (BaseField context) n r)))
 
 deriving instance Generic (UInt n r context)
-deriving instance (NFData (context (Vector (NumberOfRegisters (BaseField context) n r)))) => NFData (UInt n r context)
-deriving instance (Haskell.Eq (context (Vector (NumberOfRegisters (BaseField context) n r)))) => Haskell.Eq (UInt n r context)
-deriving instance (Haskell.Show (BaseField context), Haskell.Show (context (Vector (NumberOfRegisters (BaseField context) n r)))) => Haskell.Show (UInt n r context)
+deriving instance HNFData context => NFData (UInt n r context)
+deriving instance HEq context => Haskell.Eq (UInt n r context)
+deriving instance HShow context => Haskell.Show (UInt n r context)
 deriving newtype instance (KnownRegisters c n r, Symbolic c) => SymbolicData (UInt n r c)
 deriving newtype instance (KnownRegisters c n r, Symbolic c) => Conditional (Bool c) (UInt n r c)
 deriving newtype instance (KnownRegisters c n r, Symbolic c) => Eq (UInt n r c)
@@ -119,7 +120,6 @@ expMod
     => KnownNat (2 * m)
     => KnownRegisters c (2 * m) r
     => KnownNat (Ceil (GetRegisterSize (BaseField c) (2 * m) r) OrdWord)
-    => NFData (c (Vector (NumberOfRegisters (BaseField c) (2 * m) r)))
     => UInt n r c
     -> UInt p r c
     -> UInt m r c
@@ -146,7 +146,6 @@ bitsPow
     => KnownNat p
     => KnownRegisters c n r
     => KnownNat (Ceil (GetRegisterSize (BaseField c) n r) OrdWord)
-    => NFData (c (Vector (NumberOfRegisters (BaseField c) n r)))
     => Natural
     -> ByteString p c
     -> UInt n r c

--- a/symbolic-base/src/ZkFold/Symbolic/Data/UTCTime.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/UTCTime.hs
@@ -1,35 +1,33 @@
 {-# LANGUAGE DerivingStrategies   #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
+
 {-# OPTIONS_GHC -freduction-depth=0 #-} -- This is what our life will look like from now on if we keep using NumberOfRegisters
 
 module ZkFold.Symbolic.Data.UTCTime where
 
-import           GHC.Natural                      (Natural)
-import           GHC.TypeNats                     (KnownNat)
-import           Prelude                          hiding (Bool, Eq, Ord)
-import qualified Prelude                          as Haskell
+import           GHC.Natural                       (Natural)
+import           GHC.TypeNats                      (KnownNat)
+import           Prelude                           hiding (Bool, Eq, Ord)
+import qualified Prelude                           as Haskell
 
-import           ZkFold.Base.Algebra.Basic.Class  (FromConstant)
+import           ZkFold.Base.Algebra.Basic.Class   (FromConstant)
+import           ZkFold.Base.Data.HFunctor.Classes (HEq)
 import           ZkFold.Symbolic.Class
-import           ZkFold.Symbolic.Data.Bool        (Bool)
+import           ZkFold.Symbolic.Data.Bool         (Bool)
 import           ZkFold.Symbolic.Data.Class
-import           ZkFold.Symbolic.Data.Combinators (Ceil, GetRegisterSize, KnownRegisters, RegisterSize (..))
-import           ZkFold.Symbolic.Data.Conditional (Conditional)
-import           ZkFold.Symbolic.Data.Eq          (Eq)
-import           ZkFold.Symbolic.Data.Ord         (Ord)
+import           ZkFold.Symbolic.Data.Combinators  (Ceil, GetRegisterSize, KnownRegisters, RegisterSize (..))
+import           ZkFold.Symbolic.Data.Conditional  (Conditional)
+import           ZkFold.Symbolic.Data.Eq           (Eq)
+import           ZkFold.Symbolic.Data.Ord          (Ord)
 import           ZkFold.Symbolic.Data.UInt
 
 newtype UTCTime c = UTCTime (UInt 11 Auto c)
 
-deriving newtype instance Haskell.Eq (UInt 11 Auto c) => Haskell.Eq (UTCTime c)
-
+deriving newtype instance HEq c => Haskell.Eq (UTCTime c)
 deriving newtype instance (Symbolic c, KnownRegisters c 11 Auto) => Conditional (Bool c) (UTCTime c)
-
 deriving newtype instance (Symbolic c, KnownRegisters c 11 Auto) => Eq (UTCTime c)
-
 deriving newtype instance (Symbolic c, KnownRegisters c 11 Auto) => SymbolicData (UTCTime c)
-
 deriving newtype instance (Symbolic c, KnownRegisters c 11 Auto, regSize ~ GetRegisterSize (BaseField c) 11 Auto, KnownNat (Ceil regSize OrdWord)) => Ord (UTCTime c)
 
 deriving newtype instance FromConstant Natural (UInt 11 Auto c) => FromConstant Natural (UTCTime c)

--- a/symbolic-base/src/ZkFold/Symbolic/Data/VarByteString.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/VarByteString.hs
@@ -56,6 +56,7 @@ import           ZkFold.Symbolic.Data.Input        (SymbolicInput)
 import           ZkFold.Symbolic.Data.Ord          ((<))
 import           ZkFold.Symbolic.Interpreter
 import           ZkFold.Symbolic.MonadCircuit      (MonadCircuit, newAssigned)
+import ZkFold.Base.Data.HFunctor.Classes (HEq, HShow, HNFData)
 
 -- | A ByteString that has length unknown at compile time but guaranteed to not exceed @maxLen@.
 -- The unassigned buffer space (i.e. bits past @bsLength@) should be set to zero at all times.
@@ -69,9 +70,9 @@ data VarByteString (maxLen :: Natural) (context :: (Type -> Type) -> Type) =
         }
     deriving (Generic)
 
-deriving stock instance (Haskell.Show (ctx (Vector n)), Haskell.Show (ctx Par1)) => Haskell.Show (VarByteString n ctx)
-deriving stock instance (Haskell.Eq (ctx (Vector n)), Haskell.Eq (ctx Par1)) => Haskell.Eq (VarByteString n ctx)
-deriving anyclass instance (NFData (ctx (Vector n)), NFData (ctx Par1)) => NFData (VarByteString n ctx)
+deriving stock instance HShow ctx => Haskell.Show (VarByteString n ctx)
+deriving stock instance HEq ctx => Haskell.Eq (VarByteString n ctx)
+deriving anyclass instance HNFData ctx => NFData (VarByteString n ctx)
 deriving instance (KnownNat n, Symbolic ctx) => SymbolicData (VarByteString n ctx)
 deriving instance (KnownNat n, Symbolic ctx) => SymbolicInput (VarByteString n ctx)
 deriving instance (Symbolic ctx, KnownNat n) => Eq (VarByteString n ctx)
@@ -114,7 +115,7 @@ fromNatural :: forall n ctx . (Symbolic ctx, KnownNat n) => Natural -> Natural -
 fromNatural numBits n = VarByteString (fromConstant numBits) (fromConstant n)
 
 fromByteString :: forall n ctx . (Symbolic ctx, KnownNat n) => ByteString n ctx -> VarByteString n ctx
-fromByteString bs = VarByteString (fromConstant $ value @n) bs
+fromByteString = VarByteString (fromConstant $ value @n)
 
 instance (Symbolic ctx, KnownNat m, m * 8 ~ n) => FromJSON (VarByteString n ctx) where
     parseJSON v = fromString <$> parseJSON v
@@ -228,7 +229,7 @@ type WordSize ctx = Div (NumberOfBits (BaseField ctx)) 2
 natWordSize :: Natural -> Natural
 natWordSize n = (ilog2 (n -! 1) + 1) `div` 2
 
-withWordSize' :: forall a . (KnownNat (Order (BaseField a))) :- KnownNat (WordSize a)
+withWordSize' :: forall a . KnownNat (Order (BaseField a)) :- KnownNat (WordSize a)
 withWordSize' = Sub $ withKnownNat @(WordSize a) (unsafeSNat (natWordSize (value @(Order (BaseField a))))) Dict
 
 withWordSize :: forall a {r}. (KnownNat (Order (BaseField a))) => (KnownNat (WordSize a) => r) -> r
@@ -252,8 +253,8 @@ withWordCount =
 newtype Words n ctx = Words (ctx (Vector (WordCount n ctx)))
     deriving Generic
 
-deriving newtype instance NFData (ctx (Vector (WordCount n ctx))) => NFData (Words n ctx)
-deriving newtype instance Haskell.Show (ctx (Vector (WordCount n ctx))) => Haskell.Show (Words n ctx)
+deriving newtype instance HNFData ctx => NFData (Words n ctx)
+deriving newtype instance HShow ctx => Haskell.Show (Words n ctx)
 deriving newtype instance (KnownNat (WordCount n ctx), Symbolic ctx) => SymbolicData (Words n ctx)
 deriving newtype instance (KnownNat (WordCount n ctx), Symbolic ctx) => Conditional (Bool ctx) (Words n ctx)
 

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Vec.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Vec.hs
@@ -3,21 +3,23 @@
 
 module ZkFold.Symbolic.Data.Vec where
 
-import           Control.DeepSeq                  (NFData)
+import           Control.DeepSeq                   (NFData, NFData1)
+import           Data.Functor.Classes              (Eq1)
 import           Data.Functor.Rep
-import           Data.Traversable                 (Traversable (..))
-import           GHC.Generics                     (Generic)
-import           GHC.Num                          (Natural)
-import           Prelude                          (Integer, ($), (.))
-import qualified Prelude                          as Haskell
+import           Data.Traversable                  (Traversable (..))
+import           GHC.Generics                      (Generic)
+import           GHC.Num                           (Natural)
+import           Prelude                           (Integer, ($), (.))
+import qualified Prelude                           as Haskell
 
 import           ZkFold.Base.Algebra.Basic.Class
+import           ZkFold.Base.Data.HFunctor.Classes (HEq, HNFData)
 import           ZkFold.Symbolic.Class
-import           ZkFold.Symbolic.Data.Bool        (Bool)
+import           ZkFold.Symbolic.Data.Bool         (Bool)
 import           ZkFold.Symbolic.Data.Class
-import           ZkFold.Symbolic.Data.Combinators (mzipWithMRep)
-import           ZkFold.Symbolic.Data.Conditional (Conditional)
-import           ZkFold.Symbolic.Data.Eq          (Eq)
+import           ZkFold.Symbolic.Data.Combinators  (mzipWithMRep)
+import           ZkFold.Symbolic.Data.Conditional  (Conditional)
+import           ZkFold.Symbolic.Data.Eq           (Eq)
 import           ZkFold.Symbolic.Data.Input
 import           ZkFold.Symbolic.MonadCircuit
 
@@ -29,8 +31,8 @@ deriving newtype instance (Symbolic c, LayoutFunctor f) =>
   SymbolicInput (Vec f c)
 
 deriving instance Generic (Vec f c)
-deriving instance NFData (c f) => NFData (Vec f c)
-deriving instance Haskell.Eq (c f) => Haskell.Eq (Vec f c)
+deriving instance (HNFData c, NFData1 f) => NFData (Vec f c)
+deriving instance (HEq c, Eq1 f) => Haskell.Eq (Vec f c)
 
 deriving newtype instance (Symbolic c, LayoutFunctor f) => Eq (Vec f c)
 deriving newtype instance (Symbolic c, LayoutFunctor f) =>

--- a/symbolic-base/symbolic-base.cabal
+++ b/symbolic-base/symbolic-base.cabal
@@ -117,6 +117,7 @@ library
       ZkFold.Base.Control.HApplicative
       ZkFold.Base.Data.ByteString
       ZkFold.Base.Data.HFunctor
+      ZkFold.Base.Data.HFunctor.Classes
       ZkFold.Base.Data.List.Infinite
       ZkFold.Base.Data.Matrix
       ZkFold.Base.Data.Orphans

--- a/symbolic-base/test/Tests/Symbolic/Algorithm/Blake2b.hs
+++ b/symbolic-base/test/Tests/Symbolic/Algorithm/Blake2b.hs
@@ -15,6 +15,7 @@ import           ZkFold.Base.Algebra.Basic.Class             (FromConstant (..))
 import           ZkFold.Base.Algebra.Basic.Field             (Zp)
 import           ZkFold.Base.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar, Fr)
 import           ZkFold.Base.Data.Vector                     (Vector)
+import           ZkFold.Base.Data.HFunctor.Classes           (HEq)
 import           ZkFold.Symbolic.Algorithms.Hash.Blake2b     (blake2b_224, blake2b_512)
 import           ZkFold.Symbolic.Class                       (Symbolic)
 import           ZkFold.Symbolic.Compiler                    (ArithmeticCircuit, compile, eval1)
@@ -23,7 +24,7 @@ import           ZkFold.Symbolic.Data.ByteString             (ByteString (..))
 import qualified ZkFold.Symbolic.Data.Eq                     as Symbolic
 import           ZkFold.Symbolic.Interpreter                 (Interpreter (..))
 
-blake2bNumeric :: forall c . (Symbolic c, Eq (c (Vector 512))) => Spec
+blake2bNumeric :: forall c . (Symbolic c, HEq c) => Spec
 blake2bNumeric =
     let a = blake2b_512 @0 @c $ fromConstant (0 :: Natural)
         c = hash 64 BI.empty BI.empty
@@ -41,7 +42,7 @@ Appendix A.  Example of BLAKE2b Computation
                         18 D3 8A A8 DB F1 92 5A B9 23 86 ED D4 00 99 23
 -}
 
-blake2bExampleRfc :: forall c . (Symbolic c, Eq (c (Vector 512))) => Spec
+blake2bExampleRfc :: forall c . (Symbolic c, HEq c) => Spec
 blake2bExampleRfc =
     let abc' = blake2b_512 @3 @c $ fromConstant $ fromString @BI.ByteString "abc"
         abc  = fromConstant @_ @(ByteString 512 _) $ hash 64 BI.empty "abc"

--- a/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Contracts/ZkPass.hs
+++ b/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Contracts/ZkPass.hs
@@ -4,7 +4,6 @@
 
 module ZkFold.Symbolic.Cardano.Contracts.ZkPass where
 
--- import           Control.DeepSeq                         (NFData)
 -- import           Data.Type.Equality
 -- import           GHC.TypeLits                            (KnownNat, Log2)
 -- import qualified GHC.TypeNats
@@ -58,7 +57,6 @@ module ZkFold.Symbolic.Cardano.Contracts.ZkPass where
 --      , SemiEuclidean (UInt 256 'Auto context)
 --      , KnownNat (NumberOfRegisters (S.BaseField context) 256 'Auto)
 --      , Log2 (Order (S.BaseField context) GHC.TypeNats.- 1) ~ 255
---      , NFData (context (Vector 64))
 --      )
 --     => ByteString 256 context
 --     -> ByteString 256 context
@@ -91,7 +89,6 @@ module ZkFold.Symbolic.Cardano.Contracts.ZkPass where
 --      , SemiEuclidean (UInt 256 'Auto context)
 --      , KnownNat (NumberOfRegisters (S.BaseField context) 256 'Auto)
 --      , Log2 (Order (S.BaseField context) GHC.TypeNats.- 1) ~ 255
---      , NFData (context (Vector 64))
 --      )
 --     => ByteString 256 context
 --     -> ByteString 256 context
@@ -138,7 +135,6 @@ module ZkFold.Symbolic.Cardano.Contracts.ZkPass where
 --      , SemiEuclidean (UInt 256 'Auto context)
 --      , KnownNat (NumberOfRegisters (S.BaseField context) 256 'Auto)
 --      , Log2 (Order (S.BaseField context) GHC.TypeNats.- 1) ~ 255
---      , NFData (context (Vector 64))
 --      )
 --     =>ZKPassResult context
 --     -> Bool context

--- a/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/Address.hs
+++ b/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/Address.hs
@@ -25,9 +25,7 @@ data Address context = Address {
     }
     deriving (Generic)
 
-deriving instance (Haskell.Eq (ByteString 4 context), Haskell.Eq (ByteString 224 context))
-    => Haskell.Eq (Address context)
-
+deriving instance HEq context => Haskell.Eq (Address context)
 instance Symbolic context => Eq (Address context)
 instance Symbolic context => Conditional (Bool context) (Address context)
 instance Symbolic context => SymbolicData (Address context)

--- a/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/Input.hs
+++ b/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/Input.hs
@@ -41,23 +41,20 @@ instance
     , KnownRegisters context 64 Auto
     ) => Eq (Input tokens datum context)
 
-deriving instance
-    ( Haskell.Eq (OutputRef context)
-    , Haskell.Eq (Output tokens datum context)
-    ) => Haskell.Eq (Input tokens datum context)
+deriving instance HEq context => Haskell.Eq (Input tokens datum context)
 
 instance
   ( Symbolic context, KnownNat tokens
   , KnownRegisters context 32 Auto
   , KnownRegisters context 64 Auto
   ) => SymbolicData (Input tokens datum context)
+
 instance
   ( Symbolic context
   , KnownNat tokens
   , KnownRegisters context 32 Auto
   , KnownRegisters context 64 Auto
-  ) => SymbolicInput (Input tokens datum context) where
-  isValid (Input ior io) = isValid (ior, io)
+  ) => SymbolicInput (Input tokens datum context)
 
 txiAddress :: Input tokens datum context -> Address context
 txiAddress (Input _ txo) = txoAddress txo

--- a/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/Output.hs
+++ b/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/Output.hs
@@ -32,7 +32,7 @@ data Liability context
         }
 
 deriving instance Generic (Liability context)
-deriving instance (Haskell.Eq (SingleAsset context)) => Haskell.Eq (Liability context)
+deriving instance HEq context => Haskell.Eq (Liability context)
 deriving instance (Symbolic context, KnownRegisters context 64 Auto) => SymbolicData (Liability context)
 
 -- TODO: derive this automatically
@@ -48,13 +48,8 @@ data Output tokens datum context = Output {
         txoDatumHash :: DatumHash context
     }
 
-deriving instance
-    ( Haskell.Eq (Address context)
-    , Haskell.Eq (Value tokens context)
-    , Haskell.Eq (DatumHash context)
-    ) => Haskell.Eq (Output tokens datum context)
-
 deriving instance Generic (Output tokens datum context)
+deriving instance HEq context => Haskell.Eq (Output tokens datum context)
 deriving instance (KnownNat tokens, Symbolic context, KnownRegisters context 64 Auto) => SymbolicData (Output tokens datum context)
 
 instance
@@ -75,4 +70,3 @@ instance
     , KnownNat tokens
     , KnownRegisters context 64 Auto
     ) => Eq (Output tokens datum context)
-

--- a/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/OutputRef.hs
+++ b/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/OutputRef.hs
@@ -25,10 +25,7 @@ data OutputRef context = OutputRef {
     }
     deriving (Generic)
 
-deriving instance
-    ( Haskell.Eq (TxRefId context)
-    , Haskell.Eq (TxRefIndex context)
-    ) => Haskell.Eq (OutputRef context)
+deriving instance HEq context => Haskell.Eq (OutputRef context)
 
 instance (Symbolic context, KnownRegisters context 32 Auto)
     => SymbolicData (OutputRef context)

--- a/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/Transaction.hs
+++ b/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/Transaction.hs
@@ -28,28 +28,21 @@ data Transaction inputs rinputs outputs tokens mint datum context = Transaction 
     }
 
 deriving instance Generic (Transaction inputs rinputs outputs tokens mint datum context)
-deriving instance
-    ( Haskell.Eq (Vector rinputs (Input tokens datum context))
-    , Haskell.Eq (Vector inputs (Input tokens datum context))
-    , Haskell.Eq (Vector outputs (Output tokens datum context))
-    , Haskell.Eq (Liability context)
-    , Haskell.Eq (Value mint context)
-    , Haskell.Eq (UTCTime context)
-    ) => Haskell.Eq (Transaction inputs rinputs outputs tokens mint datum context)
+deriving instance HEq context =>
+    Haskell.Eq (Transaction inputs rinputs outputs tokens mint datum context)
 
 -- TODO: Think how to prettify this abomination
 deriving instance
     ( Symbolic context
     , KnownRegisters context 32 Auto
-    , KnownRegisters context  64 Auto
-    , KnownRegisters context  11 Auto
+    , KnownRegisters context 64 Auto
+    , KnownRegisters context 11 Auto
     , KnownNat tokens
     , KnownNat rinputs
     , KnownNat inputs
     , KnownNat outputs
     , KnownNat mint
     ) => SymbolicData (Transaction inputs rinputs outputs tokens mint datum context)
-
 
 instance
     ( Symbolic context

--- a/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/Value.hs
+++ b/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/Value.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DerivingStrategies   #-}
 {-# LANGUAGE UndecidableInstances #-}
+
 {-# OPTIONS_GHC -freduction-depth=0 #-} -- Avoid reduction overflow error caused by NumberOfRegisters
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -27,11 +28,12 @@ type SingleAsset context = ((PolicyId context, AssetName context), UInt 64 Auto 
 
 newtype Value n context = Value { getValue :: Vector n (SingleAsset context) }
 
-deriving instance (Haskell.Eq (ByteString 224 context), Haskell.Eq (ByteString 256 context), Haskell.Eq (UInt 64 Auto context))
-    => Haskell.Eq (Value n context)
-
-deriving instance (Haskell.Ord (ByteString 224 context), Haskell.Ord (ByteString 256 context), Haskell.Ord (UInt 64 Auto context))
-    => Haskell.Ord (Value n context)
+deriving instance HEq context => Haskell.Eq (Value n context)
+deriving instance ( HEq context
+                  , Haskell.Ord (ByteString 224 context)
+                  , Haskell.Ord (ByteString 256 context)
+                  , Haskell.Ord (UInt 64 Auto context)
+                  ) => Haskell.Ord (Value n context)
 
 deriving instance (Symbolic context, KnownNat n, KnownRegisters context 64 Auto) => SymbolicData (Value n context)
 

--- a/symbolic-examples/src/Examples/UInt.hs
+++ b/symbolic-examples/src/Examples/UInt.hs
@@ -11,12 +11,10 @@ module Examples.UInt (
     exampleUIntLeq,
   ) where
 
-import           Control.DeepSeq                  (NFData)
 import           Data.Type.Equality               (type (~))
 
 import           ZkFold.Base.Algebra.Basic.Class
 import           ZkFold.Base.Algebra.Basic.Number (KnownNat, type (*))
-import           ZkFold.Base.Data.Vector          (Vector)
 import           ZkFold.Symbolic.Class            (Symbolic (BaseField))
 import           ZkFold.Symbolic.Data.Combinators (Ceil, GetRegisterSize, KnownRegisterSize, KnownRegisters,
                                                    NumberOfRegisters, resize)
@@ -56,7 +54,6 @@ exampleUIntExpMod
   => KnownNat (2 * m)
   => KnownRegisters c (2 * m) r
   => KnownNat (Ceil (GetRegisterSize (BaseField c) (2 * m) r) OrdWord)
-  => NFData (c (Vector (NumberOfRegisters (BaseField c) (2 * m) r)))
   => UInt n r c
   -> UInt p r c
   -> UInt m r c


### PR DESCRIPTION
Resolves #558 and #408. Introduced new "higher-order" typeclasses `HEq`, `HShow` and `HNFData` which are then used in place of more verbose constraints like `c (Vector 10)`. `grep`-ping showed that I've performed migration where applicable, but I might've missed something.