### PR TITLE
Bump GHC version for stylish-haskell

### DIFF
--- a/.github/workflows/main-pull.yml
+++ b/.github/workflows/main-pull.yml
@@ -88,7 +88,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         cabal: [3.14.1.1]
-        ghc: [9.12.1]
+        ghc: ["9.10"]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/main-pull.yml
+++ b/.github/workflows/main-pull.yml
@@ -88,7 +88,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         cabal: [3.14.1.1]
-        ghc: [9.6.6]
+        ghc: [9.12.1]
 
     runs-on: ${{ matrix.os }}
 
@@ -106,7 +106,7 @@ jobs:
     
     - name: Install stylish-haskell
       run: |
-        cabal install stylish-haskell --allow-older --with-compiler ghc-9.6.6
+        cabal install stylish-haskell
 
     - name: Lint Haskell
       run: |


### PR DESCRIPTION
resolves issues with `stylish-haskell` by bumping the GHC version used to build it