### PR TITLE
Added `SimplePoly` newtype

### DIFF
--- a/symbolic-base/src/ZkFold/Algebra/Class.hs
+++ b/symbolic-base/src/ZkFold/Algebra/Class.hs
@@ -17,7 +17,7 @@ import           Data.List                  (map, repeat, (++))
 import           Data.Maybe                 (Maybe (..))
 import           Data.Ord                   (Ord (..))
 import           Data.Ratio                 (Rational)
-import           Data.Type.Equality         (type (~), (:~:) (..))
+import           Data.Type.Equality         (type (~))
 import           GHC.Natural                (andNatural, naturalFromInteger, shiftRNatural)
 import           Prelude                    (Integer)
 import qualified Prelude                    as Haskell
@@ -404,10 +404,6 @@ class (Ring a, Exponent a Integer, Eq a) => Field a where
     rootOfUnity :: Natural -> Maybe a
     rootOfUnity 0 = Just one
     rootOfUnity _ = Nothing
-
-    isDiscrete :: Maybe (BooleanOf a :~: Bool)
-    default isDiscrete :: BooleanOf a ~ Bool => Maybe (BooleanOf a :~: Bool)
-    isDiscrete = Just Refl
 
 intPowF :: Field a => a -> Integer -> a
 -- | A default implementation for integer exponentiation. Uses only natural
@@ -832,8 +828,6 @@ instance (Field a, Conditional (BooleanOf a) (Maybe a)) => Field (Maybe a) where
 
     rootOfUnity :: Natural -> Maybe (Maybe a)
     rootOfUnity = Just . rootOfUnity @a
-
-    isDiscrete = isDiscrete @a
 
 instance ToConstant a => ToConstant (Maybe a) where
     type Const (Maybe a) = Maybe (Const a)

--- a/symbolic-base/src/ZkFold/Algebra/Class.hs
+++ b/symbolic-base/src/ZkFold/Algebra/Class.hs
@@ -9,7 +9,7 @@ module ZkFold.Algebra.Class where
 import           Control.Applicative        (Applicative (..))
 import           Data.Bool                  (Bool (..), otherwise, (&&))
 import           Data.Foldable              (Foldable (foldl', foldl1, foldr))
-import           Data.Function              (const, id, ($), (.))
+import           Data.Function              (const, flip, id, ($), (.))
 import           Data.Functor               (Functor (..))
 import           Data.Functor.Constant      (Constant (..))
 import           Data.Kind                  (Type)
@@ -27,7 +27,7 @@ import           ZkFold.Control.Conditional (Conditional)
 import           ZkFold.Data.Eq             (BooleanOf, Eq (..))
 import           ZkFold.Prelude             (length, replicate, zipWith')
 
-infixl 7 *, /
+infixl 7 .*, *., *, /
 infixl 6 +, -, -!
 
 class Bilinear p s g | p s -> g where
@@ -105,6 +105,17 @@ class Scale b a where
     scale :: b -> a -> a
     default scale :: (FromConstant b a, MultiplicativeSemigroup a) => b -> a -> a
     scale !b !a = a * fromConstant b
+
+-- | Infix alias of 'scale'.
+(*.) :: Scale b a => b -> a -> a
+(*.) = scale
+
+-- | Flipped version of '*.'.
+--
+-- NOTE: we do not distinguish between left and right actions
+-- since multiplicative actions we are interested in are commutative.
+(.*) :: Scale b a => a -> b -> a
+(.*) = flip scale
 
 instance MultiplicativeSemigroup a => Scale a a
 

--- a/symbolic-base/src/ZkFold/Algebra/Field.hs
+++ b/symbolic-base/src/ZkFold/Algebra/Field.hs
@@ -283,8 +283,6 @@ instance (Field f, Eq f, IrreduciblePoly poly f e) => Field (Ext2 f e) where
 
     rootOfUnity n = (`Ext2` zero) <$> rootOfUnity n
 
-    isDiscrete = isDiscrete @f
-
 instance (FromConstant c poly, IrreduciblePoly poly f e) => FromConstant c (Ext2 f e) where
     fromConstant p = case fromPoly . snd $ qr (fromConstant p) (irreduciblePoly @poly @f @e) of
       []  -> zero
@@ -354,8 +352,6 @@ instance (Field f, Eq f, IrreduciblePoly poly f e) => Field (Ext3 f e) where
             v      -> Ext3 (v V.! 0) (v V.! 1) (v V.! 2)
 
     rootOfUnity n = (\r -> Ext3 r zero zero) <$> rootOfUnity n
-
-    isDiscrete = isDiscrete @f
 
 instance (FromConstant c poly, IrreduciblePoly poly f e) => FromConstant c (Ext3 f e) where
     fromConstant p = case fromPoly . snd $ qr (fromConstant p) (irreduciblePoly @poly @f @e) of

--- a/symbolic-base/src/ZkFold/Algebra/Number.hs
+++ b/symbolic-base/src/ZkFold/Algebra/Number.hs
@@ -15,6 +15,7 @@ module ZkFold.Algebra.Number
     , Mod
     , Div
     , value
+    , integral
     , type (<=)
     , type (*)
     , type (+)
@@ -22,18 +23,23 @@ module ZkFold.Algebra.Number
     , type (^)
     ) where
 
+import           Data.Bool      (Bool (..))
 import           Data.Kind      (Constraint)
 import           Data.Type.Bool (If, type (&&))
 import           GHC.Exts       (proxy#)
+import           GHC.Real       (Integral)
+import qualified GHC.Real       as Integral
 import           GHC.TypeLits   (ErrorMessage (..), TypeError)
 import           GHC.TypeNats
-import           Prelude        (Bool (..))
 
 -- Use orphan instances for large publicly verified primes
 class KnownNat p => Prime p
 
 value :: forall n . KnownNat n => Natural
 value = natVal' (proxy# @n)
+
+integral :: forall size n . (KnownNat size, Integral n) => n
+integral = Integral.fromIntegral (value @size)
 
 -- Use this overlappable instance for small enough primes and testing
 instance {-# OVERLAPPABLE #-} (KnownNat p, KnownPrime p) => Prime p

--- a/symbolic-base/src/ZkFold/Algebra/Polynomial/Univariate.hs
+++ b/symbolic-base/src/ZkFold/Algebra/Polynomial/Univariate.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE NoGeneralisedNewtypeDeriving #-}
 {-# LANGUAGE QuantifiedConstraints        #-}
 {-# LANGUAGE TypeApplications             #-}
-{-# LANGUAGE TypeOperators                #-}
 {-# LANGUAGE UndecidableInstances         #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -28,7 +27,6 @@ module ZkFold.Algebra.Polynomial.Univariate
 
 import           Control.DeepSeq       (NFData (..))
 import           Control.Monad         (forM_)
-import           Data.Type.Equality    ((:~:) (..))
 import qualified Data.Vector           as V
 import qualified Data.Vector.Mutable   as VM
 import           GHC.Generics          (Generic)
@@ -40,7 +38,6 @@ import           Test.QuickCheck       (Arbitrary (..), chooseInt)
 import           ZkFold.Algebra.Class  hiding (Euclidean (..))
 import           ZkFold.Algebra.DFT    (genericDft)
 import           ZkFold.Algebra.Number
-import qualified ZkFold.Data.Eq        as ZkFold
 import           ZkFold.Prelude        (log2ceiling, replicate, zipVectorsWithDefault, zipWithDefault)
 
 infixl 7 .*, *., .*., ./.
@@ -199,7 +196,7 @@ mulAdaptive !l !r
             -------------------------------------------------------------------------------------------------
 
             resultLen :: Int
-            resultLen = (V.length l) P.+ (V.length r) P.- 1
+            resultLen = V.length l P.+ V.length r P.- 1
 
             dftP :: Integer
             dftP = ceiling @Double $ logBase 2 (fromIntegral resultLen)
@@ -341,19 +338,19 @@ class
     , forall size . (KnownNat size) => AdditiveGroup (pv size)
     ) => UnivariateRingPolyVec c pv | pv -> c where
 
--- -- | Multiply the corresponding coefficients of two polynomials.
+    -- | Multiply the corresponding coefficients of two polynomials.
     (.*.) :: forall size . (KnownNat size) => pv size -> pv size -> pv size
 
--- -- | Multiply every coefficient of the polynomial by a constant.
+    -- | Multiply every coefficient of the polynomial by a constant.
     (.*) :: forall size . (KnownNat size) => pv size -> c -> pv size
 
--- -- | Multiply every coefficient of the polynomial by a constant.
+    -- | Multiply every coefficient of the polynomial by a constant.
     (*.) :: forall size . (KnownNat size) => c -> pv size -> pv size
 
--- -- | Add a constant to every coefficient of the polynomial.
+    -- | Add a constant to every coefficient of the polynomial.
     (.+) :: forall size . (KnownNat size) => pv size -> c -> pv size
 
--- -- | Add a constant to every coefficient of the polynomial.
+    -- | Add a constant to every coefficient of the polynomial.
     (+.) :: forall size . (KnownNat size) => c -> pv size -> pv size
 
     toPolyVec :: forall size . (KnownNat size) => V.Vector c -> pv size
@@ -364,17 +361,17 @@ class
 
     vec2poly :: forall poly size . (KnownNat size, UnivariateRingPolynomial c poly) => pv size -> poly
 
-    -- -- p(x) = a0
+    -- | p(x) = a0
     polyVecConstant :: forall size . (KnownNat size) => c -> pv size
 
-    -- p(x) = a1 * x + a0
+    -- | (polyVecLinear a1 a0)(x) = a1 * x + a0
     polyVecLinear
         :: forall size . (KnownNat size)
         => c -- ^ a1
         -> c -- ^ a0
         -> pv size
 
-    -- p(x) = a2 * x^2 + a1 * x + a0
+    -- | (polyVecQuadratic a2 a1 a0)(x) = a2 * x^2 + a1 * x + a0
     polyVecQuadratic
         :: forall size . (KnownNat size)
         => c -- ^ a2
@@ -391,16 +388,16 @@ class
     , UnivariateRingPolyVec c pv
     ) => UnivariateFieldPolyVec c pv | pv -> c where
 
--- -- | Divide the corresponding coefficients of two polynomials.
+    -- | Divide the corresponding coefficients of two polynomials.
     (./.) :: forall size . (KnownNat size) => pv size -> pv size -> pv size
 
--- -- p(x) = x^n - 1
+    -- | p(x) = x^n - 1
     polyVecZero :: forall size . (KnownNat size) => Natural -> pv size
 
--- -- L_i(x) : p(omega^i) = 1, p(omega^j) = 0, j /= i, 1 <= i <= n, 1 <= j <= n
+    -- | L_i(x) : p(omega^i) = 1, p(omega^j) = 0, j /= i, 1 <= i <= n, 1 <= j <= n
     polyVecLagrange :: forall size . (KnownNat size) => Natural -> Natural -> c -> pv size
 
--- -- p(x) = c_1 * L_1(x) + c_2 * L_2(x) + ... + c_n * L_n(x)
+    -- | p(x) = c_1 * L_1(x) + c_2 * L_2(x) + ... + c_n * L_n(x)
     polyVecInLagrangeBasis :: forall n size . (KnownNat size, KnownNat n) => c -> pv n -> pv size
 
     polyVecGrandProduct :: forall size . (KnownNat size) => pv size -> pv size -> pv size -> c -> c -> pv size
@@ -438,7 +435,7 @@ instance
     vec2poly :: forall poly size . (KnownNat size, UnivariateRingPolynomial c poly) => PolyVec c size -> poly
     vec2poly = toPoly . fromPolyVec
 
-    -- -- p(x) = a0
+    -- p(x) = a0
     polyVecConstant :: forall size . c -> PolyVec c size
     polyVecConstant a0 = PV $ V.singleton a0
 
@@ -465,7 +462,7 @@ instance
     polyVecZero n = poly2vec $ scaleP one n (one @(Poly c)) - one @(Poly c)
 
     polyVecLagrange :: forall size . (KnownNat size) => Natural -> Natural -> c -> PolyVec c size
-    polyVecLagrange n i omega = toPolyVec $ (V.unfoldrExactN vecLen coefficients (norm * wi^(n -! 1), n))
+    polyVecLagrange n i omega = toPolyVec $ V.unfoldrExactN vecLen coefficients (norm * wi^(n -! 1), n)
         where
             wi = omega ^ i
 
@@ -508,26 +505,25 @@ instance
 
     castPolyVec :: forall size size' . (KnownNat size, KnownNat size') => PolyVec c size -> PolyVec c size'
     castPolyVec (PV cs)
-        | value @size <= value @size'                             = toPolyVec $ cs
-        | all (== zero) (V.drop (fromIntegral (value @size')) cs) = toPolyVec $ cs
+        | value @size <= value @size'                             = toPolyVec cs
+        | all (== zero) (V.drop (fromIntegral (value @size')) cs) = toPolyVec cs
         | otherwise = error "castPolyVec: Cannot cast polynomial vector to smaller size!"
 
 -- | Determines whether a polynomial is of the form 'ax^m + b' (m > 0) and returns @Just (m, a, b)@ if so.
 -- Multiplication and division by polynomials of such form can be performed much faster than with general algorithms.
 --
-isShiftedMono :: forall c . Field c => V.Vector c -> Maybe (Natural, c, c)
-isShiftedMono cs = isDiscrete @c >>= \case
-    Refl
-     | V.length filtered /= 2 -> Nothing
-     | otherwise -> case V.toList filtered of
+isShiftedMono :: forall c . (Field c, Eq c) => V.Vector c -> Maybe (Natural, c, c)
+isShiftedMono cs
+    | V.length filtered /= 2 = Nothing
+    | otherwise = case V.toList filtered of
         [(c0, 0), (cm, m)] -> pure (m, cm, c0)
         _                  -> Nothing
     where
         ixed :: V.Vector (c, Natural)
         ixed = V.zip cs $ V.iterateN (V.length cs) succ 0
 
-        filtered :: ZkFold.BooleanOf c ~ Bool => V.Vector (c, Natural)
-        filtered = V.filter ((ZkFold./= zero) . fst) ixed
+        filtered :: V.Vector (c, Natural)
+        filtered = V.filter ((/= zero) . fst) ixed
 
 
 -- | Efficiently divide a polynomial by a monic 'shifted monomial' of the form x^m + b, m > 0
@@ -580,7 +576,7 @@ instance (Ring c, Eq c, KnownNat size) => AdditiveSemigroup (PolyVec c size) whe
     PV l + PV r = toPolyVec $ zipVectorsWithDefault zero (+) l r
 
 instance (Ring c, Eq c, KnownNat size) => AdditiveMonoid (PolyVec c size) where
-    zero = PV $ V.empty
+    zero = PV V.empty
 
 instance (Ring c, Eq c, KnownNat size) => AdditiveGroup (PolyVec c size) where
     negate (PV cs) = PV $ fmap negate cs

--- a/symbolic-base/src/ZkFold/Algebra/Polynomial/Univariate/Simple.hs
+++ b/symbolic-base/src/ZkFold/Algebra/Polynomial/Univariate/Simple.hs
@@ -2,10 +2,12 @@
 
 module ZkFold.Algebra.Polynomial.Univariate.Simple
     ( SimplePoly (coeffs)
+    , fromVector
     , toVector
     ) where
 
-import           Data.Function                        (($), (.))
+import qualified Data.Eq                              as Haskell
+import           Data.Function                        (on, ($), (.))
 import           Data.Functor                         (fmap)
 import           Data.List                            (zip)
 import           Data.Ord                             (min, (<))
@@ -16,6 +18,7 @@ import           Data.Vector                          (Vector)
 import qualified Data.Vector                          as V
 import qualified GHC.Num                              as Int
 import           Numeric.Natural                      (Natural)
+import           Text.Show                            (Show)
 
 import           ZkFold.Algebra.Class
 import           ZkFold.Algebra.Number                (KnownNat, integral)
@@ -27,7 +30,7 @@ import qualified ZkFold.Data.Vector                   as ZkFold
 --
 -- Not particularly efficient, but still usable in Symbolic
 -- since its operations do not require 'Prelude.Eq'.
-newtype SimplePoly a n = SimplePoly
+newtype SimplePoly a (n :: Natural) = SimplePoly
     { coeffs :: V.Vector a
       -- ^ Vector of coefficients in ascending-degree order.
       --
@@ -38,6 +41,15 @@ newtype SimplePoly a n = SimplePoly
       -- NOTE since 'SimplePoly' does not use 'Prelude.Eq', it is possible that
       -- there are some non-zeroed greater coefficients. Use with care.
     }
+    deriving (Show)
+
+instance
+    (AdditiveMonoid a, Haskell.Eq a, KnownNat n) =>
+    Haskell.Eq (SimplePoly a n) where
+    (==) = (Haskell.==) `on` toVector
+
+fromVector :: forall a n. ZkFold.Vector n a -> SimplePoly a n
+fromVector (ZkFold.Vector cs) = SimplePoly cs
 
 -- | Vector of exactly @n@ coefficients in ascending-degree order.
 toVector ::

--- a/symbolic-base/src/ZkFold/Algebra/Polynomial/Univariate/Simple.hs
+++ b/symbolic-base/src/ZkFold/Algebra/Polynomial/Univariate/Simple.hs
@@ -5,7 +5,7 @@ module ZkFold.Algebra.Polynomial.Univariate.Simple
     , toVector
     ) where
 
-import           Data.Function                        (flip, ($), (.))
+import           Data.Function                        (($), (.))
 import           Data.Functor                         (fmap)
 import           Data.List                            (zip)
 import           Data.Ord                             (min, (<))
@@ -92,17 +92,9 @@ instance (Ring a, KnownNat n) => Ring (SimplePoly a n)
 instance Ring a => UnivariateRingPolyVec a (SimplePoly a) where
     SimplePoly p .*. SimplePoly q =
         SimplePoly $ alignWith (uncurry (*) . T.fromThese zero zero) p q
-    (.*) = flip scale
-    (*.) = scale
-    (+.) c = SimplePoly . fmap (c +) . coeffs
-    (.+) = flip (+.)
+    (+.) c = SimplePoly . ZkFold.toV . fmap (c +) . toVector
     toPolyVec :: forall n . KnownNat n => Vector a -> SimplePoly a n
     toPolyVec = SimplePoly . V.take (integral @n)
     fromPolyVec = coeffs
-    poly2vec = toPolyVec . fromPoly
-    vec2poly = toPoly . fromPolyVec
-    polyVecConstant = fromConstant
-    polyVecLinear k b = toPolyVec (V.fromList [b, k])
-    polyVecQuadratic a b c = toPolyVec (V.fromList [c, b, a])
     evalPolyVec (SimplePoly p) x =
         sum [ c * x ^ i | (i, c) <- zip [(0 :: Natural)..] (V.toList p) ]

--- a/symbolic-base/src/ZkFold/Algebra/Polynomial/Univariate/Simple.hs
+++ b/symbolic-base/src/ZkFold/Algebra/Polynomial/Univariate/Simple.hs
@@ -79,7 +79,7 @@ instance
                         l -> min (integral @n) (l Int.- 1)
          in SimplePoly $ V.generate pqLen \k -> sum [
             (p V.! i) * (q V.! j)
-            | i <- [0 .. min pLen k], let j = k Int.- i, j < qLen
+            | i <- [0 .. min (pLen Int.- 1) k], let j = k Int.- i, j < qLen
          ]
 
 instance (Semiring a, KnownNat n) => MultiplicativeMonoid (SimplePoly a n) where

--- a/symbolic-base/src/ZkFold/Algebra/Polynomial/Univariate/Simple.hs
+++ b/symbolic-base/src/ZkFold/Algebra/Polynomial/Univariate/Simple.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE BlockArguments #-}
+
+module ZkFold.Algebra.Polynomial.Univariate.Simple
+    ( SimplePoly (coeffs)
+    , toVector
+    ) where
+
+import           Data.Function                        (flip, ($), (.))
+import           Data.Functor                         (fmap)
+import           Data.List                            (zip)
+import           Data.Ord                             (min, (<))
+import           Data.Semialign                       (alignWith)
+import qualified Data.These                           as T
+import           Data.Tuple                           (uncurry)
+import           Data.Vector                          (Vector)
+import qualified Data.Vector                          as V
+import qualified GHC.Num                              as Int
+import           Numeric.Natural                      (Natural)
+
+import           ZkFold.Algebra.Class
+import           ZkFold.Algebra.Number                (KnownNat, integral)
+import           ZkFold.Algebra.Polynomial.Univariate
+import qualified ZkFold.Data.Vector                   as ZkFold
+
+-- | A "simple" polynomial-vector type, meaning that
+-- it uses a simple multiplication algorithm.
+--
+-- Not particularly efficient, but still usable in Symbolic
+-- since its operations do not require 'Prelude.Eq'.
+newtype SimplePoly a n = SimplePoly
+    { coeffs :: V.Vector a
+      -- ^ Vector of coefficients in ascending-degree order.
+      --
+      -- NOTE there is no guarantee that length of 'coeffs' is @n@,
+      -- only that its length is _not greater than_ @n@.
+      -- To get correctly sized vector, use 'toVector'.
+      --
+      -- NOTE since 'SimplePoly' does not use 'Prelude.Eq', it is possible that
+      -- there are some non-zeroed greater coefficients. Use with care.
+    }
+
+-- | Vector of exactly @n@ coefficients in ascending-degree order.
+toVector ::
+    forall a n . (AdditiveMonoid a, KnownNat n) =>
+    SimplePoly a n -> ZkFold.Vector n a
+toVector (SimplePoly cs) =
+    ZkFold.Vector $ cs V.++ V.replicate (integral @n Int.- V.length cs) zero
+
+instance {-# OVERLAPPING #-} FromConstant (SimplePoly a n) (SimplePoly a n)
+
+instance FromConstant k a => FromConstant k (SimplePoly a n) where
+    fromConstant = SimplePoly . V.singleton . fromConstant
+
+instance {-# OVERLAPPING #-}
+    (Semiring a, KnownNat n) => Scale (SimplePoly a n) (SimplePoly a n)
+
+instance Scale k a => Scale k (SimplePoly a n) where
+    scale k = SimplePoly . fmap (scale k) . coeffs
+
+instance (Semiring a, KnownNat n) => Exponent (SimplePoly a n) Natural where
+    (^) = natPow
+
+instance AdditiveSemigroup a => AdditiveSemigroup (SimplePoly a n) where
+    SimplePoly p + SimplePoly q = SimplePoly $ alignWith (T.mergeThese (+)) p q
+
+instance AdditiveMonoid a => AdditiveMonoid (SimplePoly a n) where
+    zero = SimplePoly V.empty
+
+instance AdditiveGroup a => AdditiveGroup (SimplePoly a n) where
+    negate = SimplePoly . fmap negate . coeffs
+
+instance
+    (Semiring a, KnownNat n) => MultiplicativeSemigroup (SimplePoly a n) where
+    SimplePoly p * SimplePoly q =
+        let pLen = V.length p
+            qLen = V.length q
+            pqLen = case pLen Int.+ qLen of
+                        0 -> 0
+                        l -> min (integral @n) (l Int.- 1)
+         in SimplePoly $ V.generate pqLen \k -> sum [
+            (p V.! i) * (q V.! j)
+            | i <- [0 .. min pLen k], let j = k Int.- i, j < qLen
+         ]
+
+instance (Semiring a, KnownNat n) => MultiplicativeMonoid (SimplePoly a n) where
+    one = fromConstant (one :: a)
+
+instance (Semiring a, KnownNat n) => Semiring (SimplePoly a n)
+
+instance (Ring a, KnownNat n) => Ring (SimplePoly a n)
+
+instance Ring a => UnivariateRingPolyVec a (SimplePoly a) where
+    SimplePoly p .*. SimplePoly q =
+        SimplePoly $ alignWith (uncurry (*) . T.fromThese zero zero) p q
+    (.*) = flip scale
+    (*.) = scale
+    (+.) c = SimplePoly . fmap (c +) . coeffs
+    (.+) = flip (+.)
+    toPolyVec :: forall n . KnownNat n => Vector a -> SimplePoly a n
+    toPolyVec = SimplePoly . V.take (integral @n)
+    fromPolyVec = coeffs
+    poly2vec = toPolyVec . fromPoly
+    vec2poly = toPoly . fromPolyVec
+    polyVecConstant = fromConstant
+    polyVecLinear k b = toPolyVec (V.fromList [b, k])
+    polyVecQuadratic a b c = toPolyVec (V.fromList [c, b, a])
+    evalPolyVec (SimplePoly p) x =
+        sum [ c * x ^ i | (i, c) <- zip [(0 :: Natural)..] (V.toList p) ]

--- a/symbolic-base/src/ZkFold/Data/Matrix.hs
+++ b/symbolic-base/src/ZkFold/Data/Matrix.hs
@@ -36,8 +36,9 @@ outer :: forall m n a b c. (a -> b -> c) -> Vector m a -> Vector n b -> Matrix m
 outer f a b = Matrix $ fmap (\x -> fmap (f x) b) a
 
 -- | Hadamard (entry-wise) matrix product
-(.*) :: MultiplicativeSemigroup a => Matrix m n a -> Matrix m n a -> Matrix m n a
-(.*) = zipWith (*)
+instance
+    MultiplicativeSemigroup a => MultiplicativeSemigroup (Matrix m n a) where
+    (*) = zipWith (*)
 
 sum1 :: (Semiring a) => Matrix m n a -> Vector n a
 sum1 (Matrix as) = Vector (sum <$> toV as)
@@ -46,7 +47,7 @@ sum2 :: (KnownNat m, KnownNat n, Semiring a) => Matrix m n a -> Vector m a
 sum2 (Matrix as) = sum1 $ transpose $ Matrix as
 
 matrixDotProduct :: forall m n a . Semiring a => Matrix m n a -> Matrix m n a -> a
-matrixDotProduct a b = let Matrix m = a .* b in sum $ fmap sum m
+matrixDotProduct a b = let Matrix m = a * b in sum $ fmap sum m
 
 -- -- | Matrix multiplication
 (.*.) :: (KnownNat n, KnownNat k, Semiring a) => Matrix m n a -> Matrix n k a -> Matrix m k a

--- a/symbolic-base/src/ZkFold/Data/Matrix.hs
+++ b/symbolic-base/src/ZkFold/Data/Matrix.hs
@@ -6,7 +6,6 @@ module ZkFold.Data.Matrix where
 import qualified Data.List             as List
 import           Data.Maybe            (fromJust)
 import           Data.These
-import           Data.Zip              (Semialign (..), Zip (..))
 import           Prelude               hiding (Num (..), length, sum, zip, zipWith)
 import           System.Random         (Random (..))
 import           Test.QuickCheck       (Arbitrary (..))

--- a/symbolic-base/src/ZkFold/Data/Vector.hs
+++ b/symbolic-base/src/ZkFold/Data/Vector.hs
@@ -3,7 +3,10 @@
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeOperators       #-}
 
-module ZkFold.Data.Vector where
+module ZkFold.Data.Vector
+    ( module ZkFold.Data.Vector
+    , module Data.Zip
+    ) where
 
 import           Control.Applicative        (Applicative, pure)
 import           Control.DeepSeq            (NFData, NFData1)

--- a/symbolic-base/src/ZkFold/Data/Vector.hs
+++ b/symbolic-base/src/ZkFold/Data/Vector.hs
@@ -58,14 +58,10 @@ instance (KnownNat n, Eq x) => Eq (Vector n x) where
     u == v = V.foldl (&&) true (V.zipWith (==) (toV u) (toV v))
     u /= v = V.foldl (||) false (V.zipWith (/=) (toV u) (toV v))
 
--- helper
-knownNat :: forall size n . (KnownNat size, P.Integral n) => n
-knownNat = P.fromIntegral (value @size)
-
 instance KnownNat size => Representable (Vector size) where
   type Rep (Vector size) = Zp size
   index (Vector v) ix = v V.! P.fromIntegral (fromZp ix)
-  tabulate f = Vector (V.generate (knownNat @size) (f . P.fromIntegral))
+  tabulate f = Vector (V.generate (integral @size) (f . P.fromIntegral))
 
 instance KnownNat size => Distributive (Vector size) where
   distribute = distributeRep
@@ -73,7 +69,7 @@ instance KnownNat size => Distributive (Vector size) where
 
 vtoVector :: forall size a . KnownNat size => V.Vector a -> Maybe (Vector size a)
 vtoVector as
-  | V.length as == knownNat @size = Just $ Vector as
+  | V.length as == integral @size = Just $ Vector as
   | otherwise                     = Nothing
 
 instance IsList (Vector n a) where
@@ -90,7 +86,7 @@ unsafeToVector :: forall size a . [a] -> Vector size a
 unsafeToVector = Vector . V.fromList
 
 unfold :: forall size a b. KnownNat size => (b -> (a, b)) -> b -> Vector size a
-unfold f = Vector . V.unfoldrExactN (knownNat @size) f
+unfold f = Vector . V.unfoldrExactN (integral @size) f
 
 fromVector :: Vector size a -> [a]
 fromVector (Vector !as) = V.toList as
@@ -136,13 +132,13 @@ mapMWithIx f (Vector !l) = Vector <$> V.zipWithM f (V.enumFromTo 0 (value @n -! 
 
 -- TODO: Check that n <= size?
 take :: forall n size a. KnownNat n => Vector size a -> Vector n a
-take (Vector !lst) = Vector (V.take (knownNat @n) lst)
+take (Vector !lst) = Vector (V.take (integral @n) lst)
 
 drop :: forall n m a. KnownNat n => Vector (n + m) a -> Vector m a
-drop (Vector !lst) = Vector (V.drop (knownNat @n) lst)
+drop (Vector !lst) = Vector (V.drop (integral @n) lst)
 
 splitAt :: forall n m a. KnownNat n => Vector (n + m) a -> (Vector n a, Vector m a)
-splitAt (Vector !lst) = (Vector (V.take (knownNat @n) lst), Vector (V.drop (knownNat @n) lst))
+splitAt (Vector !lst) = (Vector (V.take (integral @n) lst), Vector (V.drop (integral @n) lst))
 
 rotate :: forall size a. KnownNat size => Vector size a -> Integer -> Vector size a
 rotate (Vector !lst) n = Vector (r <> l)
@@ -157,7 +153,7 @@ rotate (Vector !lst) n = Vector (r <> l)
 
 shift :: forall size a. KnownNat size => Vector size a -> Integer -> a -> Vector size a
 shift (Vector lst) n pad
-  | n P.< 0 = Vector $ V.take (knownNat @size) (padList <> lst)
+  | n P.< 0 = Vector $ V.take (integral @size) (padList <> lst)
   | otherwise = Vector $ V.drop (P.fromIntegral n) (lst <> padList)
     where
         padList = V.replicate (P.fromIntegral $ P.abs n) pad
@@ -205,10 +201,10 @@ backpermute (Vector v) (Vector is) = Vector $ V.backpermute v $ V.map (P.fromInt
 
 instance (KnownNat n, Binary a) => Binary (Vector n a) where
     put = fold . V.map put . toV
-    get = Vector <$> V.replicateM (knownNat @n) get
+    get = Vector <$> V.replicateM (integral @n) get
 
 instance KnownNat size => Applicative (Vector size) where
-    pure a = Vector $ V.replicate (knownNat @size) a
+    pure a = Vector $ V.replicate (integral @size) a
 
     (Vector !fs) <*> (Vector !as) = Vector $ V.zipWith ($) fs as
 

--- a/symbolic-base/src/ZkFold/Protocol/IVC/Internal.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/Internal.hs
@@ -21,7 +21,7 @@ import qualified Prelude                                            as P
 
 import           ZkFold.Algebra.Class
 import           ZkFold.Algebra.Number                              (KnownNat, type (+))
-import           ZkFold.Algebra.Polynomial.Univariate               (PolyVec)
+import           ZkFold.Algebra.Polynomial.Univariate.Simple        (SimplePoly)
 import           ZkFold.Data.Vector                                 (Vector, singleton)
 import           ZkFold.Protocol.IVC.Accumulator                    hiding (pi)
 import qualified ZkFold.Protocol.IVC.AccumulatorScheme              as Acc
@@ -82,7 +82,7 @@ type IVCAssumptions ctx0 ctx1 algo d k a i p c f =
     , RandomOracle algo (c f) f
     , HomomorphicCommit [f] (c f)
     , Scale a f
-    , Scale a (PolyVec f (d+1))
+    , Scale a (SimplePoly f (d + 1))
     , Scale f (c f)
     , ctx0 ~ Interpreter a
     , RecursiveFunctionAssumptions algo d a i c (FieldElement ctx0) ctx0

--- a/symbolic-base/src/ZkFold/Protocol/IVC/RecursiveFunction.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/RecursiveFunction.hs
@@ -18,11 +18,10 @@ import           Data.Zip                                           (Semialign (
 import           GHC.Generics                                       (Generic, Generic1, U1 (..), (:*:) (..))
 import           Prelude                                            (Foldable, Functor, Show, Traversable, fmap,
                                                                      type (~), ($), (.), (<$>))
-import qualified Prelude                                            as P
 
 import           ZkFold.Algebra.Class                               (Scale, zero)
 import           ZkFold.Algebra.Number                              (KnownNat, type (+), type (-))
-import           ZkFold.Algebra.Polynomial.Univariate               (PolyVec)
+import           ZkFold.Algebra.Polynomial.Univariate.Simple        (SimplePoly)
 import           ZkFold.Data.ByteString                             (Binary1)
 import           ZkFold.Data.Orphans                                ()
 import           ZkFold.Data.Package                                (packed, unpacked)
@@ -86,9 +85,8 @@ type RecursiveFunctionAssumptions algo d a i c f ctx =
     , RandomOracle algo (c f) f
     , HomomorphicCommit [f] (c f)
     , Scale a f
-    , Scale a (PolyVec f (d+1))
+    , Scale a (SimplePoly f (d + 1))
     , Scale f (c f)
-    , P.Eq f
     )
 
 type RecursiveFunction algo d k a i p c = forall f ctx . RecursiveFunctionAssumptions algo d a i c f ctx

--- a/symbolic-base/src/ZkFold/Protocol/Plonk/Prover.hs
+++ b/symbolic-base/src/ZkFold/Protocol/Plonk/Prover.hs
@@ -233,7 +233,8 @@ plonkProve PlonkupProverSetup {..}
             --   + (alpha5 * lag1_xi) *. (z2X - one)
               - zhX_xi *. (qlowX + (xi^(n+2)) *. qmidX + (xi^(2*n+4)) *. qhighX)
 
-        vn i = v ^ (i :: Natural)
+        vn :: Natural -> ScalarFieldOf g1
+        vn i = v ^ i
 
         proofX1 = with4n6 @n $ (
                   rX

--- a/symbolic-base/src/ZkFold/Protocol/Plonkup/Prover.hs
+++ b/symbolic-base/src/ZkFold/Protocol/Plonkup/Prover.hs
@@ -163,17 +163,16 @@ plonkupProve PlonkupProverSetup {..}
         !deltaX   = polyVecConstant delta
         !epsilonX = polyVecConstant epsilon
 
-        !qXs1 = (qmX * aX * bX + qlX * aX + qrX * bX + qoX * cX + piX + qcX)
-        !qXs2 = ((aX + polyVecLinear beta gamma) * (bX + polyVecLinear (beta * k1) gamma) * (cX + polyVecLinear (beta * k2) gamma) * z1X .* alpha)
-        !qXs3 = ((aX + (beta *. s1X) + gammaX) * (bX + (beta *. s2X) + gammaX) * (cX + (beta *. s3X) + gammaX) * (z1X .*. omegas') .* alpha)
-        !qXs4 = ((z1X - one) * polyVecLagrange (value @n) 1 omega .* alpha2)
-        !qXs5 = (qkX * (aX + zeta *. (bX + zeta *. cX) - fX) .* alpha3)
-        !qXs6 = (z2X * (one + deltaX) * (epsilonX + fX) * ((epsilonX * (one + deltaX)) + tX + deltaX * (tX .*. omegas')) .* alpha4)
-        !qXs7 = ((z2X .*. omegas') * ((epsilonX * (one + deltaX)) + h1X + deltaX * h2X) * ((epsilonX * (one + deltaX)) + h2X + deltaX * (h1X .*. omegas')) .* alpha4)
-        !qXs8 = ((z2X - one) * polyVecLagrange (value @n) 1 omega .* alpha5)
+        !qXs1 = qmX * aX * bX + qlX * aX + qrX * bX + qoX * cX + piX + qcX
+        !qXs2 = (aX + polyVecLinear beta gamma) * (bX + polyVecLinear (beta * k1) gamma) * (cX + polyVecLinear (beta * k2) gamma) * z1X .* alpha
+        !qXs3 = (aX + (beta *. s1X) + gammaX) * (bX + (beta *. s2X) + gammaX) * (cX + (beta *. s3X) + gammaX) * (z1X .*. omegas') .* alpha
+        !qXs4 = (z1X - one) * polyVecLagrange (value @n) 1 omega .* alpha2
+        !qXs5 = qkX * (aX + zeta *. (bX + zeta *. cX) - fX) .* alpha3
+        !qXs6 = z2X * (one + deltaX) * (epsilonX + fX) * ((epsilonX * (one + deltaX)) + tX + deltaX * (tX .*. omegas')) .* alpha4
+        !qXs7 = (z2X .*. omegas') * ((epsilonX * (one + deltaX)) + h1X + deltaX * h2X) * ((epsilonX * (one + deltaX)) + h2X + deltaX * (h1X .*. omegas')) .* alpha4
+        !qXs8 = (z2X - one) * polyVecLagrange (value @n) 1 omega .* alpha5
 
-        !qXNumerator = (
-                qXs1
+        !qXNumerator = qXs1
               + qXs2
               - qXs3
               + qXs4
@@ -181,7 +180,6 @@ plonkupProve PlonkupProverSetup {..}
               + qXs6
               - qXs7
               + qXs8
-            )
 
         !qX = qXNumerator `polyVecDiv` zhX
 
@@ -250,7 +248,8 @@ plonkupProve PlonkupProverSetup {..}
               + (alpha5 * lag1_xi) *. (z2X - one)
               - zhX_xi *. (qlowX + (xi^(n+2)) *. qmidX + (xi^(2*n+4)) *. qhighX)
 
-        vn i = v ^ (i :: Natural)
+        vn :: Natural -> ScalarFieldOf g1
+        vn i = v ^ i
 
         !proofX1 = (
                   rX

--- a/symbolic-base/src/ZkFold/Protocol/Plonkup/Relation.hs
+++ b/symbolic-base/src/ZkFold/Protocol/Plonkup/Relation.hs
@@ -132,7 +132,6 @@ instance Eq a => Eq (Vector a) where
 
 instance Field a => Field (Vector a) where
     finv = fmap finv
-    isDiscrete = isDiscrete @a
 
 instance SemiEuclidean a => SemiEuclidean (Vector a) where
     div = zipLongest div

--- a/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MerkleHash.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/MerkleHash.hs
@@ -79,7 +79,6 @@ instance Eq (MerkleHash n) where
 
 instance Field (MerkleHash (Just n)) where
   finv (M x) = merkleHash (Mul, x)
-  isDiscrete = Nothing
 
 instance Finite (Zp n) => ResidueField (MerkleHash (Just n)) where
   type IntegralOf (MerkleHash (Just n)) = MerkleHash Nothing

--- a/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Witness.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/Witness.hs
@@ -5,7 +5,6 @@ import           Control.DeepSeq              (NFData (..), rwhnf)
 import           Control.Monad                (Monad (..), ap)
 import           Data.Function                (const, (.))
 import           Data.Functor                 (Functor)
-import           Data.Maybe                   (Maybe (Nothing))
 import           Numeric.Natural              (Natural)
 import           Prelude                      (Integer)
 
@@ -59,7 +58,6 @@ instance Eq (WitnessF a v) where
 instance Field (WitnessF a v) where
   finv (WitnessF f) = WitnessF (finv . f)
   WitnessF f // WitnessF g = WitnessF (\x -> f x // g x)
-  isDiscrete = Nothing
 instance Finite a => Finite (WitnessF a v) where type Order (WitnessF a v) = Order a
 instance Finite a => ResidueField (WitnessF a v) where
   type IntegralOf (WitnessF a v) = EuclideanF a v

--- a/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/WitnessEstimation.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Compiler/ArithmeticCircuit/WitnessEstimation.hs
@@ -96,7 +96,6 @@ instance Eq a => ZkFold.Eq (UVar a) where
 instance (Field a, Eq a) => Field (UVar a) where
     finv (ConstUVar c) = ConstUVar (finv c)
     finv _             = More
-    isDiscrete         = Nothing
 
 instance Finite a => Finite (UVar a) where
     type Order (UVar a) = Order a

--- a/symbolic-base/src/ZkFold/Symbolic/Data/FFA.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/FFA.hs
@@ -310,8 +310,6 @@ instance (Symbolic c, KnownFFA p r c, Prime p) => Field (FFA p r c) where
               return (ni :*: ui)
         , U1 :*: U1)
 
-  isDiscrete = Prelude.Nothing
-
 instance Finite (Zp p) => Finite (FFA p r c) where
   type Order (FFA p r c) = p
 

--- a/symbolic-base/src/ZkFold/Symbolic/Data/FieldElement.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/FieldElement.hs
@@ -92,7 +92,6 @@ instance Symbolic c => Field (FieldElement c) where
   finv (FieldElement x) =
     FieldElement $ symbolicF x (\(Par1 v) -> Par1 (finv v))
       $ fmap snd . runInvert
-  isDiscrete = Haskell.Nothing
 
 instance
     ( KnownNat (Order (FieldElement c))

--- a/symbolic-base/src/ZkFold/Symbolic/Data/MerkleTree.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/MerkleTree.hs
@@ -18,7 +18,7 @@ import           Prelude                             (const, pure, return, zip, 
 import qualified Prelude                             as P
 
 import           ZkFold.Algebra.Class
-import           ZkFold.Algebra.Number               (value)
+import           ZkFold.Algebra.Number               (integral, value)
 import           ZkFold.Data.Package
 import qualified ZkFold.Data.Vector                  as V
 import           ZkFold.Data.Vector                  hiding ((.:))
@@ -169,7 +169,7 @@ findPath p mt@(MerkleTree _ nodes) = withDict (minusNat @d @1) $ bool (nothing @
 
 indToPath :: forall c d. (Symbolic c, KnownNat d) => c Par1 -> Vector (d - 1) (c Par1)
 indToPath e = unpack $ fromCircuitF e $ \(Par1 i) -> do
-    ee <- expansion (knownNat @d) i
+    ee <- expansion (integral @d) i
     return $ Comp1 (V.unsafeToVector @(d-1) $ P.map Par1 ee)
 
 -- | Returns the element corresponding to a path

--- a/symbolic-base/src/ZkFold/Symbolic/Data/MerkleTree.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/MerkleTree.hs
@@ -21,7 +21,7 @@ import           ZkFold.Algebra.Class
 import           ZkFold.Algebra.Number               (integral, value)
 import           ZkFold.Data.Package
 import qualified ZkFold.Data.Vector                  as V
-import           ZkFold.Data.Vector                  hiding ((.:), zip)
+import           ZkFold.Data.Vector                  hiding (zip, (.:))
 import           ZkFold.Symbolic.Algorithm.Hash.MiMC
 import           ZkFold.Symbolic.Class
 import           ZkFold.Symbolic.Data.Bool           (Bool (..), BoolType (false))

--- a/symbolic-base/src/ZkFold/Symbolic/Data/MerkleTree.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/MerkleTree.hs
@@ -21,7 +21,7 @@ import           ZkFold.Algebra.Class
 import           ZkFold.Algebra.Number               (integral, value)
 import           ZkFold.Data.Package
 import qualified ZkFold.Data.Vector                  as V
-import           ZkFold.Data.Vector                  hiding ((.:))
+import           ZkFold.Data.Vector                  hiding ((.:), zip)
 import           ZkFold.Symbolic.Algorithm.Hash.MiMC
 import           ZkFold.Symbolic.Class
 import           ZkFold.Symbolic.Data.Bool           (Bool (..), BoolType (false))

--- a/symbolic-base/symbolic-base.cabal
+++ b/symbolic-base/symbolic-base.cabal
@@ -347,6 +347,7 @@ test-suite symbolic-base-test
       Tests.Algebra.Univariate
       Tests.Algebra.Univariate.Poly
       Tests.Algebra.Univariate.PolyVec
+      Tests.Algebra.Univariate.Simple
       Tests.Data.Binary
       Tests.Protocol.IVC
       Tests.Protocol.NonInteractiveProof

--- a/symbolic-base/symbolic-base.cabal
+++ b/symbolic-base/symbolic-base.cabal
@@ -115,6 +115,7 @@ library
       ZkFold.Algebra.Polynomial.Multivariate.Internal
       ZkFold.Algebra.Polynomial.Multivariate.Substitution
       ZkFold.Algebra.Polynomial.Univariate
+      ZkFold.Algebra.Polynomial.Univariate.Simple
       ZkFold.Algorithm.ReedSolomon
       ZkFold.Control.Conditional
       ZkFold.Control.HApplicative

--- a/symbolic-base/test/Tests/Algebra/Univariate.hs
+++ b/symbolic-base/test/Tests/Algebra/Univariate.hs
@@ -3,8 +3,10 @@ module Tests.Algebra.Univariate (specUnivariate) where
 import           Test.Hspec                       (Spec)
 import           Tests.Algebra.Univariate.Poly    (specUnivariatePoly)
 import           Tests.Algebra.Univariate.PolyVec (specUnivariatePolyVec)
+import           Tests.Algebra.Univariate.Simple  (specSimplePoly)
 
 specUnivariate :: Spec
 specUnivariate = do
     specUnivariatePoly
     specUnivariatePolyVec
+    specSimplePoly

--- a/symbolic-base/test/Tests/Algebra/Univariate/Simple.hs
+++ b/symbolic-base/test/Tests/Algebra/Univariate/Simple.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BlockArguments      #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Tests.Algebra.Univariate.Simple where
+
+import           Data.Eq                                     (Eq, (/=))
+import           Data.Function                               (($))
+import           Data.Functor                                (fmap, (<$>))
+import           Data.Semigroup                              ((<>))
+import           Data.String                                 (String)
+import           Data.Typeable
+import qualified Test.Hspec                                  as Hspec
+import           Test.Hspec                                  (Spec)
+import qualified Test.QuickCheck                             as QC
+import           Test.QuickCheck                             ((=/=), (===), (==>))
+import           Text.Show                                   (Show, show)
+
+import           ZkFold.Algebra.Class
+import           ZkFold.Algebra.EllipticCurve.BLS12_381      (Fq, Fr)
+import           ZkFold.Algebra.Number
+import           ZkFold.Algebra.Polynomial.Univariate
+import           ZkFold.Algebra.Polynomial.Univariate.Simple
+import           ZkFold.Data.Vector                          (Vector, toV, zipWith)
+
+typeAt :: forall a. Typeable a => TypeRep
+typeAt = typeRep (Proxy :: Proxy a)
+
+it :: QC.Testable prop => String -> prop -> Hspec.SpecWith (Hspec.Arg QC.Property)
+it desc prop = Hspec.it desc (QC.property prop)
+
+instance (QC.Arbitrary a, KnownNat n) => QC.Arbitrary (SimplePoly a n) where
+    arbitrary = fromVector <$> QC.arbitrary
+
+specSimplePoly' ::
+    forall a n .
+    (QC.Arbitrary a, Eq a, Field a, Show a, Typeable a, KnownNat n) => Spec
+specSimplePoly' = Hspec.describe (show (typeAt @(SimplePoly a n)) <> " spec") do
+    Hspec.describe "vec2poly" do
+        it "respects addition" \(p :: SimplePoly a n) q ->
+            vec2poly (p + q) === vec2poly p + (vec2poly q :: Poly a)
+        it "respects zero" $
+            vec2poly (zero :: SimplePoly a n) === (zero :: Poly a)
+        it "respects negation" \(p :: SimplePoly a n) ->
+            vec2poly (negate p) === negate (vec2poly p :: Poly a)
+        it "respects action" \(p :: SimplePoly a n) (c :: a) ->
+            vec2poly (c *. p) === c *. (vec2poly p :: Poly a)
+        it "completes evalPoly to evalPolyVec" \(p :: SimplePoly a n) x ->
+            evalPolyVec p x === evalPoly (vec2poly p :: Poly a) x
+    Hspec.describe "poly2vec" do
+        it "respects addition" \(p :: Poly a) q ->
+            poly2vec (p + q) === poly2vec p + (poly2vec q :: SimplePoly a n)
+        it "respects zero" $
+            poly2vec (zero :: Poly a) === (zero :: SimplePoly a n)
+        it "respects negation" \(p :: Poly a) ->
+            poly2vec (negate p) === negate (poly2vec p :: SimplePoly a n)
+        it "respects multiplication" \(p :: Poly a) q ->
+            poly2vec (p * q) === poly2vec p * (poly2vec q :: SimplePoly a n)
+        it "respects action" \(p :: Poly a) (c :: a) ->
+            poly2vec (c *. p) === c *. (poly2vec p :: SimplePoly a n)
+        it "is left inverse to vec2poly" \(p :: SimplePoly a n) ->
+            poly2vec (vec2poly p :: Poly a) === p
+        -- NOTE: correctness of group & scale instances for @SimplePoly a n@
+        -- follow from the properties given above,
+        -- assuming instances for @Poly a@ are correct.
+    it "is quotient modulo divisor of x^n" $
+        poly2vec (monomial (value @n) one :: Poly a) === (zero :: SimplePoly a n)
+    it "is quotient modulo x^n" \(p :: Vector n a) ->
+        p /= zero ==> toPolyVec (toV p) =/= (zero :: SimplePoly a n)
+    it "implements fromVector correctly" \(p :: Vector n a) ->
+        fromVector p === toPolyVec (toV p)
+    it "implements hadamard correctly" \(p :: Vector n a) q ->
+        fromVector p .*. fromVector q === fromVector (zipWith (*) p q)
+    it "implements additive action correctly" \(p :: Vector n a) c ->
+        c +. fromVector p === fromVector (fmap (c +) p)
+
+specSimplePoly :: Spec
+specSimplePoly = do
+    specSimplePoly' @Fr @32
+    specSimplePoly' @Fr @128
+    specSimplePoly' @Fq @32
+    specSimplePoly' @Fq @128


### PR DESCRIPTION
Added a vector-backed `SimplePoly` newtype for use in `Symbolic` where previously `PolyVec` were used.
Also removed `isDiscrete` since it's not used anymore and breaks abstraction.