### PR TITLE
+ Empty typeclass

### DIFF
--- a/symbolic-base/src/ZkFold/Data/Empty.hs
+++ b/symbolic-base/src/ZkFold/Data/Empty.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE TypeOperators #-}
+
+module ZkFold.Data.Empty where
+
+import           Data.Function    (const, ($))
+import           Data.Functor.Rep (Representable, tabulate)
+import           GHC.Generics     (U1 (..), (:*:) (..), (:.:) (..))
+
+-- TODO: Most likely temporary.
+-- Remove once we get rid of Layout/Payload split in SymbolicData.
+
+class Empty f where
+    empty :: f a
+
+instance Empty U1 where
+    empty = U1
+
+instance (Empty f, Empty g) => Empty (f :*: g) where
+    empty = empty :*: empty
+
+instance (Representable f, Empty g) => Empty (f :.: g) where
+    empty = Comp1 $ tabulate (const empty)

--- a/symbolic-base/symbolic-base.cabal
+++ b/symbolic-base/symbolic-base.cabal
@@ -120,6 +120,7 @@ library
       ZkFold.Control.HApplicative
       ZkFold.Data.Bool
       ZkFold.Data.ByteString
+      ZkFold.Data.Empty
       ZkFold.Data.Eq
       ZkFold.Data.HFunctor
       ZkFold.Data.HFunctor.Classes


### PR DESCRIPTION
Adds new `Empty` typeclass for functors which are, well, empty -- in the sense that they do not contain any data.
Can be viewed as a superclass to `Alternative`, but has completely separate usecases. In particular, we can use `Empty` to constrain Symbolic datatypes which actually do not have any payload, meaning that it is `Empty`.