### PR TITLE
Fixed compiler performance benchmark

### DIFF
--- a/symbolic-base/src/ZkFold/Symbolic/Compiler.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Compiler.hs
@@ -34,6 +34,7 @@ import ZkFold.Symbolic.MonadCircuit (MonadCircuit (..))
 -- for function of type @f@ to be compilable.
 type CompilesWith c s f =
   ( SymbolicFunction f
+  , SymbolicData (Range f)
   , Context (Range f) ~ c
   , Domain f ~ s
   , SymbolicInput s
@@ -62,7 +63,8 @@ compileWith
 compileWith opts support f = restore . (,U1) . optimize $ opts \x ->
   let input = restore . bimap fool (fmap pure) $ swap (support x)
       Bool b = isValid input
-   in fromCircuit2F (apply f input) b \r (Par1 i) -> do
+      output = apply f input
+   in fromCircuit2F (arithmetize output) b \r (Par1 i) -> do
         constraint (one - ($ i))
         return r
 

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Class.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Class.hs
@@ -310,10 +310,10 @@ type family Range a where
 
 class (LayoutFunctor (Layout (Range f)), Domain (Range f) ~ Proxy (Context (Range f))) => SymbolicFunction f where
   -- | Converts a function to a symbolic context.
-  apply :: f -> Domain f -> (Context (Range f)) (Layout (Range f))
+  apply :: f -> Domain f -> Range f
 
 instance {-# OVERLAPPING #-} SymbolicFunction y => SymbolicFunction (x -> y) where
   apply f (x, y) = apply (f x) y
 
 instance {-# OVERLAPPABLE #-} (SymbolicData x, Range x ~ x, Domain x ~ Proxy (Context x)) => SymbolicFunction x where
-  apply x _ = arithmetize x
+  apply x _ = x

--- a/symbolic-examples/bench/CircuitSize.hs
+++ b/symbolic-examples/bench/CircuitSize.hs
@@ -10,6 +10,7 @@ import System.IO (IO)
 import qualified Test.Tasty as Tasty
 import qualified Test.Tasty.Golden as Golden
 import Text.Show (Show (..))
+import ZkFold.Symbolic.Compiler (compile)
 import ZkFold.Symbolic.Compiler.ArithmeticCircuit (ArithmeticCircuit)
 import qualified ZkFold.Symbolic.Compiler.ArithmeticCircuit as Circuit
 
@@ -35,5 +36,5 @@ main =
       "Compiler golden tests"
       [ Golden.goldenVsString name ("stats/" <> name) $ pure (metrics name circuit)
       | (name, ExampleOutput cf) <- Examples.examples
-      , let circuit = cf ()
+      , let circuit = compile cf
       ]

--- a/symbolic-examples/src/ZkFold/Symbolic/Examples.hs
+++ b/symbolic-examples/src/ZkFold/Symbolic/Examples.hs
@@ -2,19 +2,13 @@
 
 module ZkFold.Symbolic.Examples (ExampleOutput (..), examples) where
 
-import Control.DeepSeq (NFData1)
-import Data.Function (const, ($), (.))
-import Data.Functor.Rep (Rep, Representable)
+import Data.Function (($))
 import Data.String (String)
 import Data.Type.Equality (type (~))
-import GHC.Generics (type (:*:))
 import ZkFold.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
 import ZkFold.Algebra.EllipticCurve.Pasta (FpModulus)
 import ZkFold.Algebra.Field (Zp)
 import ZkFold.Data.ByteString (Binary)
-import ZkFold.Symbolic.Class (Arithmetic)
-import ZkFold.Symbolic.Compiler (compile)
-import ZkFold.Symbolic.Compiler.ArithmeticCircuit (ArithmeticCircuit)
 import ZkFold.Symbolic.Compiler.ArithmeticCircuit.Context (CircuitContext)
 import ZkFold.Symbolic.Data.Bool (true)
 import ZkFold.Symbolic.Data.ByteString (ByteString)
@@ -43,30 +37,27 @@ type A = Zp BLS12_381_Scalar
 
 type B = Zp FpModulus
 
-type C a = ArithmeticCircuit a
-
 data ExampleOutput where
   ExampleOutput
     :: forall a i o
-     . (Representable i, Binary (Rep i), NFData1 o, Arithmetic a)
-    => (() -> C a i o)
+     . ( Binary a
+       , SymbolicInput i, Context i ~ CircuitContext a
+       , SymbolicData o, Context o ~ CircuitContext a)
+    => (i -> o)
     -> ExampleOutput
 
 exampleOutput
-  :: forall a i o c f
-   . ( SymbolicFunction f
-     , c ~ CircuitContext a
-     , Context (Range f) ~ c
-     , Layout (Range f) ~ o
+  :: forall a f
+   . ( Binary a
+     , SymbolicFunction f
      , SymbolicInput (Domain f)
-     , Context (Domain f) ~ c
-     , i ~ Payload (Domain f) :*: Layout (Domain f)
-     , NFData1 o
-     , Binary a
+     , Context (Domain f) ~ CircuitContext a
+     , SymbolicData (Range f)
+     , Context (Range f) ~ CircuitContext a
      )
   => f
   -> ExampleOutput
-exampleOutput = ExampleOutput @a @i @o . const . compile
+exampleOutput f = ExampleOutput (apply f)
 
 examples :: [(String, ExampleOutput)]
 examples =

--- a/symbolic-examples/symbolic-examples.cabal
+++ b/symbolic-examples/symbolic-examples.cabal
@@ -133,7 +133,6 @@ library
       base                          >= 4.9 && < 5,
       base16-bytestring                          ,
       bytestring                                 ,
-      deepseq                                    ,
       deriving-aeson                             ,
       symbolic-base                              ,
       text                                       ,


### PR DESCRIPTION
Resolves #552.

For evaluation, my code was benchmarking the creation of the `NewVar -> a` function, not the actual evaluation. In the fix, a complete application of `eval :: AC a i o -> i a -> o a` is benchmarked instead.

For compilation, previous version of my code was creating a node in an evaluation graph per circuit which ended up being reused between benchmarks. In the fix, an `ExampleOutput` contains a function to compile, not the compiled circuit, so the compilation restarts correctly between runs.