### PR TITLE
Making sure `compileIO` works for our datatypes

### DIFF
--- a/symbolic-base/src/ZkFold/Data/Orphans.hs
+++ b/symbolic-base/src/ZkFold/Data/Orphans.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TemplateHaskell #-}
+
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module ZkFold.Data.Orphans where
@@ -8,7 +10,8 @@ module ZkFold.Data.Orphans where
 import Control.Applicative ((<*>))
 import Control.DeepSeq (NFData, NFData1)
 import Control.Monad (return)
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (FromJSON, ToJSON, ToJSON1 (..))
+import Data.Aeson.TH (deriveToJSON1, defaultOptions)
 import Data.Binary (Binary)
 import Data.Functor (Functor, (<$>))
 import Data.Functor.Rep (Representable (..), WrappedRep (..))
@@ -44,16 +47,24 @@ instance ToJSON a => ToJSON (U1 a)
 
 instance FromJSON a => FromJSON (U1 a)
 
+instance ToJSON1 U1
+
 instance ToJSON a => ToJSON (Par1 a)
 
 instance FromJSON a => FromJSON (Par1 a)
+
+instance ToJSON1 Par1
 
 instance (ToJSON a, ToJSON (f a), ToJSON (g a)) => ToJSON ((:*:) f g a)
 
 instance (FromJSON a, FromJSON (f a), FromJSON (g a)) => FromJSON ((:*:) f g a)
 
+instance (ToJSON1 f, ToJSON1 g) => ToJSON1 (f :*: g)
+
 instance (ToJSON a, ToJSON (f (g a)), ToJSON (g a)) => ToJSON ((:.:) f g a)
 
 instance (FromJSON a, FromJSON (f (g a)), FromJSON (g a)) => FromJSON ((:.:) f g a)
+
+$(deriveToJSON1 defaultOptions ''(:.:))
 
 deriving newtype instance Binary (Rep f) => Binary (WrappedRep f)

--- a/symbolic-base/src/ZkFold/Data/Orphans.hs
+++ b/symbolic-base/src/ZkFold/Data/Orphans.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE TemplateHaskell #-}
-
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module ZkFold.Data.Orphans where
@@ -11,7 +10,7 @@ import Control.Applicative ((<*>))
 import Control.DeepSeq (NFData, NFData1)
 import Control.Monad (return)
 import Data.Aeson (FromJSON, ToJSON, ToJSON1 (..))
-import Data.Aeson.TH (deriveToJSON1, defaultOptions)
+import Data.Aeson.TH (defaultOptions, deriveToJSON1)
 import Data.Binary (Binary)
 import Data.Functor (Functor, (<$>))
 import Data.Functor.Rep (Representable (..), WrappedRep (..))

--- a/symbolic-base/src/ZkFold/Data/Vector.hs
+++ b/symbolic-base/src/ZkFold/Data/Vector.hs
@@ -12,7 +12,7 @@ import Control.Applicative (Applicative, pure)
 import Control.DeepSeq (NFData, NFData1)
 import Control.Monad (Monad)
 import Control.Monad.State.Strict (runState, state)
-import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Aeson (FromJSON (..), ToJSON (..), ToJSON1)
 import Data.Bool (otherwise)
 import Data.Constraint.Nat (Max)
 import Data.Distributive (Distributive (..))
@@ -49,7 +49,7 @@ import ZkFold.Prelude (length)
 
 newtype Vector (size :: Natural) a = Vector {toV :: V.Vector a}
   deriving (Eq1, Foldable, Functor, Generic, NFData, NFData1, P.Eq, P.Ord, Show, Show1, Traversable)
-  deriving newtype (FromJSON, ToJSON)
+  deriving newtype (FromJSON, ToJSON, ToJSON1)
 
 instance Eq x => Eq (Vector n x) where
   type BooleanOf (Vector n x) = BooleanOf x

--- a/symbolic-base/test/Tests/Symbolic/Compiler.hs
+++ b/symbolic-base/test/Tests/Symbolic/Compiler.hs
@@ -1,6 +1,6 @@
 module Tests.Symbolic.Compiler (specCompiler) where
 
-import Data.Function (($), id)
+import Data.Function (id, ($))
 import Data.Proxy (Proxy)
 import Test.Hspec (Spec, describe)
 
@@ -8,11 +8,11 @@ import Tests.Symbolic.Compiler.CompileWith (specCompileWith)
 import Tests.Symbolic.Compiler.Optimization (specOptimization)
 import ZkFold.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
 import ZkFold.Algebra.Field (Zp)
-import ZkFold.Symbolic.Data.FieldElement (FieldElement)
-import ZkFold.Symbolic.Data.UInt (UInt)
-import ZkFold.Symbolic.Data.Combinators (RegisterSize (Auto))
 import ZkFold.ArithmeticCircuit.Context (CircuitContext)
 import ZkFold.Symbolic.Compiler (compileIO)
+import ZkFold.Symbolic.Data.Combinators (RegisterSize (Auto))
+import ZkFold.Symbolic.Data.FieldElement (FieldElement)
+import ZkFold.Symbolic.Data.UInt (UInt)
 
 type A = Zp BLS12_381_Scalar
 
@@ -21,7 +21,8 @@ type C = CircuitContext A
 specCompiler :: Spec
 specCompiler = do
   describe "Compiler specification" $ do
-    let _ = -- compile-time test
-            compileIO @A "ex" $ id @(FieldElement C, Proxy C, UInt 32 Auto C)
+    let _ =
+          -- compile-time test
+          compileIO @A "ex" $ id @(FieldElement C, Proxy C, UInt 32 Auto C)
     specCompileWith @A
     specOptimization @A

--- a/symbolic-base/test/Tests/Symbolic/Compiler.hs
+++ b/symbolic-base/test/Tests/Symbolic/Compiler.hs
@@ -1,15 +1,27 @@
 module Tests.Symbolic.Compiler (specCompiler) where
 
-import Data.Function (($))
+import Data.Function (($), id)
+import Data.Proxy (Proxy)
 import Test.Hspec (Spec, describe)
 
 import Tests.Symbolic.Compiler.CompileWith (specCompileWith)
 import Tests.Symbolic.Compiler.Optimization (specOptimization)
 import ZkFold.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
 import ZkFold.Algebra.Field (Zp)
+import ZkFold.Symbolic.Data.FieldElement (FieldElement)
+import ZkFold.Symbolic.Data.UInt (UInt)
+import ZkFold.Symbolic.Data.Combinators (RegisterSize (Auto))
+import ZkFold.ArithmeticCircuit.Context (CircuitContext)
+import ZkFold.Symbolic.Compiler (compileIO)
+
+type A = Zp BLS12_381_Scalar
+
+type C = CircuitContext A
 
 specCompiler :: Spec
 specCompiler = do
   describe "Compiler specification" $ do
-    specCompileWith @(Zp BLS12_381_Scalar)
-    specOptimization @(Zp BLS12_381_Scalar)
+    let _ = -- compile-time test
+            compileIO @A "ex" $ id @(FieldElement C, Proxy C, UInt 32 Auto C)
+    specCompileWith @A
+    specOptimization @A


### PR DESCRIPTION
Resolves #402. Performed on top of #631 and #632 so these have to be merged first.

For this, I had to add some orphan `ToJSON1` instances -- the `ToJSONKey` instance for `Zp` was actually already present.

Also added a compile-time test to check that calls to `compileIO` typecheck just fine.