### PR TITLE
newtypes for elliptic curve points

### DIFF
--- a/symbolic-base/src/ZkFold/Symbolic/Data/EllipticCurve/Points.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/EllipticCurve/Points.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE RebindableSyntax #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+
+module ZkFold.Symbolic.Data.EllipticCurve.Points where
+
+import GHC.Generics
+import Prelude (type (~))
+
+import ZkFold.Algebra.EllipticCurve.Class
+import ZkFold.Data.Eq
+import ZkFold.Symbolic.Data.Bool
+import ZkFold.Symbolic.Data.Class
+
+
+-- Defining instances for 'SymbolicData':
+
+newtype SymbolicPoint point = SymbolicPoint point
+  deriving Generic
+
+instance
+  ( SymbolicData (BooleanOf field)
+  , SymbolicData field
+  , Context field ~ Context (BooleanOf field)
+  )
+  => SymbolicData (SymbolicPoint (Point field))
+
+instance
+  ( SymbolicData field
+  , Context field ~ Context (BooleanOf field)
+  )
+  => SymbolicData (SymbolicPoint (JacobianPoint field))
+
+instance SymbolicData field => SymbolicData (SymbolicPoint (AffinePoint field))
+
+deriving newtype instance
+  SymbolicEq field
+  => SymbolicData (Weierstrass curve (SymbolicPoint (Point field)))
+
+deriving newtype instance
+  SymbolicEq field
+  => SymbolicData (Weierstrass curve (SymbolicPoint (JacobianPoint field)))
+
+deriving newtype instance
+  SymbolicData field
+  => SymbolicData (TwistedEdwards curve (SymbolicPoint (AffinePoint field)))
+
+
+{-
+
+-- Next we should define instances for 'SymbolicInput'.  After some experimentation, these
+-- appear to be more challenging.
+
+instance
+  ( WeierstrassCurve curve field
+  , SymbolicEq field
+  )
+  => SymbolicInput (Weierstrass curve (SymbolicPoint (Point field)))
+  where
+  isValid = isOnCurve
+
+instance
+  ( WeierstrassCurve curve field
+  , SymbolicEq field
+  )
+  => SymbolicInput (Weierstrass curve (SymbolicPoint (JacobianPoint field)))
+  where
+  isValid = isOnCurve
+
+-}

--- a/symbolic-base/symbolic-base.cabal
+++ b/symbolic-base/symbolic-base.cabal
@@ -234,6 +234,7 @@ library
       ZkFold.Symbolic.Data.EllipticCurve.Jubjub
       ZkFold.Symbolic.Data.EllipticCurve.Pasta
       ZkFold.Symbolic.Data.EllipticCurve.PlutoEris
+      ZkFold.Symbolic.Data.EllipticCurve.Points
       ZkFold.Symbolic.Data.EllipticCurve.Secp256k1
       ZkFold.Symbolic.Data.FFA
       ZkFold.Symbolic.Data.FieldElement


### PR DESCRIPTION
## Task description

Currently, the types from ZkFold.Algebra.* are re-used as SymbolicData types. In particular, instances of SymbolicData, SymbolicInput, and SymbolicOutput are defined in ZkFold.Algebra.*modules. We should define newtypes for elliptic curve points in Symbolic and remove those instances from ZkFold.Algebra.* modules.