### PR TITLE
IVC update

### DIFF
--- a/symbolic-base/src/ZkFold/ArithmeticCircuit/WitnessEstimation.hs
+++ b/symbolic-base/src/ZkFold/ArithmeticCircuit/WitnessEstimation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module ZkFold.ArithmeticCircuit.WitnessEstimation where
@@ -9,14 +10,14 @@ import Data.Eq (Eq, (==))
 import Data.Function ((.))
 import Data.Functor (Functor, fmap)
 import Data.Maybe (Maybe (..))
-import Prelude (Integral)
-
 import ZkFold.Algebra.Class
 import ZkFold.ArithmeticCircuit.Var (NewVar)
 import ZkFold.Control.Conditional (Conditional (..))
 import ZkFold.Data.Bool
+import ZkFold.Data.Eq (BooleanOf)
 import qualified ZkFold.Data.Eq as ZkFold
 import ZkFold.Symbolic.MonadCircuit (IntegralOf, ResidueField, fromIntegral, toIntegral)
+import Prelude (Integral)
 
 data UVar a = ConstUVar a | LinUVar a NewVar a | More deriving Functor
 
@@ -101,7 +102,7 @@ instance (Field a, Eq a) => Field (UVar a) where
 instance Finite a => Finite (UVar a) where
   type Order (UVar a) = Order a
 
-instance (ResidueField a, Eq a) => ResidueField (UVar a) where
+instance (ResidueField a, Eq a, Conditional (BooleanOf (IntegralOf a)) (Maybe (IntegralOf a))) => ResidueField (UVar a) where
   type IntegralOf (UVar a) = Maybe (IntegralOf a)
   fromIntegral (Just x) = ConstUVar (fromIntegral x)
   fromIntegral Nothing = More

--- a/symbolic-base/src/ZkFold/Protocol/IVC/Accumulator.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/Accumulator.hs
@@ -12,6 +12,7 @@ import Data.Binary (Binary)
 import Data.Functor.Rep (Representable (..))
 import GHC.Generics (Generic)
 import ZkFold.Algebra.Class (Ring, Scale, zero)
+import ZkFold.Algebra.EllipticCurve.Class (ScalarFieldOf)
 import ZkFold.Algebra.Number (KnownNat, type (+), type (-))
 import ZkFold.Data.Vector (Vector)
 import ZkFold.Protocol.IVC.AlgebraicMap (algebraicMap)
@@ -80,17 +81,18 @@ emptyAccumulator
      , Foldable i
      , Representable p
      , Foldable p
-     , HomomorphicCommit [f] c
+     , HomomorphicCommit c
      , Ring f
      , Scale a f
      , Binary (Rep i)
      , Binary (Rep p)
+     , f ~ ScalarFieldOf c
      )
   => Predicate a i p
   -> Accumulator k i c f
 emptyAccumulator phi =
   let accW = tabulate (const zero)
-      aiC = fmap hcommit accW
+      aiC = tabulate (const zero)
       aiR = tabulate (const zero)
       aiMu = zero
       aiPI = tabulate (const zero)
@@ -107,11 +109,12 @@ emptyAccumulatorInstance
      , Foldable i
      , Representable p
      , Foldable p
-     , HomomorphicCommit [f] c
+     , HomomorphicCommit c
      , Ring f
      , Scale a f
      , Binary (Rep i)
      , Binary (Rep p)
+     , f ~ ScalarFieldOf c
      )
   => Predicate a i p
   -> AccumulatorInstance k i c f

--- a/symbolic-base/src/ZkFold/Protocol/IVC/Accumulator.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/Accumulator.hs
@@ -9,18 +9,27 @@ import Control.Lens ((^.))
 import Control.Lens.Combinators (makeLenses)
 import Data.Bifunctor (Bifunctor (..))
 import Data.Binary (Binary)
-import Data.Functor.Rep (Representable (..))
+import qualified Data.Eq as Haskell
+import Data.Foldable (Foldable)
+import Data.Function (const, ($))
+import Data.Functor (Functor (..))
+import Data.Functor.Rep (Representable (..), mzipWithRep)
 import GHC.Generics (Generic)
 import ZkFold.Algebra.Class (Ring, Scale, zero)
 import ZkFold.Algebra.EllipticCurve.Class (ScalarFieldOf)
 import ZkFold.Algebra.Number (KnownNat, type (+), type (-))
+import ZkFold.Data.Bool (BoolType (..), and)
+import ZkFold.Data.Eq (Eq (..))
 import ZkFold.Data.Vector (Vector)
 import ZkFold.Protocol.IVC.AlgebraicMap (algebraicMap)
 import ZkFold.Protocol.IVC.Commit (HomomorphicCommit (..))
 import ZkFold.Protocol.IVC.Oracle
 import ZkFold.Protocol.IVC.Predicate (Predicate)
 import ZkFold.Symbolic.Data.Class (LayoutData (..), LayoutFunctor, SymbolicData (..))
-import Prelude hiding (length, pi)
+import ZkFold.Symbolic.MonadCircuit (ResidueField (..))
+import Prelude (type (~))
+
+-- import Prelude hiding (length, pi)
 
 -- Page 19, Accumulator instance
 data AccumulatorInstance k i c f = AccumulatorInstance
@@ -30,9 +39,24 @@ data AccumulatorInstance k i c f = AccumulatorInstance
   , _e :: c -- E ∈ C in the paper
   , _mu :: f -- μ ∈ F in the paper
   }
-  deriving (Eq, Functor, Generic)
+  deriving (Haskell.Eq, Functor, Generic)
 
 makeLenses ''AccumulatorInstance
+
+instance (ResidueField f, LayoutFunctor i, Eq c, BooleanOf (IntegralOf f) ~ BooleanOf c) => Eq (AccumulatorInstance k i c f) where
+  type BooleanOf (AccumulatorInstance k i c f) = BooleanOf (IntegralOf f)
+  acc1 == acc2 =
+    and (mzipWithRep (==) (fmap toIntegral $ layoutData $ _pi acc1) (fmap toIntegral $ layoutData $ _pi acc2))
+      && _c acc1
+      == _c acc2
+      && fmap toIntegral (_r acc1)
+      == fmap toIntegral (_r acc2)
+      && _e acc1
+      == _e acc2
+      && toIntegral (_mu acc1)
+      == toIntegral (_mu acc2)
+  acc1 /= acc2 =
+    not (acc1 == acc2)
 
 instance Functor i => Bifunctor (AccumulatorInstance k i) where
   bimap f g AccumulatorInstance {..} =

--- a/symbolic-base/src/ZkFold/Protocol/IVC/Accumulator.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/Accumulator.hs
@@ -11,8 +11,6 @@ import Data.Bifunctor (Bifunctor (..))
 import Data.Binary (Binary)
 import Data.Functor.Rep (Representable (..))
 import GHC.Generics (Generic)
-import Prelude hiding (length, pi)
-
 import ZkFold.Algebra.Class (Ring, Scale, zero)
 import ZkFold.Algebra.Number (KnownNat, type (+), type (-))
 import ZkFold.Data.Vector (Vector)
@@ -21,6 +19,7 @@ import ZkFold.Protocol.IVC.Commit (HomomorphicCommit (..))
 import ZkFold.Protocol.IVC.Oracle
 import ZkFold.Protocol.IVC.Predicate (Predicate)
 import ZkFold.Symbolic.Data.Class (LayoutData (..), LayoutFunctor, SymbolicData (..))
+import Prelude hiding (length, pi)
 
 -- Page 19, Accumulator instance
 data AccumulatorInstance k i c f = AccumulatorInstance
@@ -78,6 +77,9 @@ emptyAccumulator
      , KnownNat (k - 1)
      , KnownNat k
      , Representable i
+     , Foldable i
+     , Representable p
+     , Foldable p
      , HomomorphicCommit [f] c
      , Ring f
      , Scale a f
@@ -102,6 +104,9 @@ emptyAccumulatorInstance
      , KnownNat (k - 1)
      , KnownNat k
      , Representable i
+     , Foldable i
+     , Representable p
+     , Foldable p
      , HomomorphicCommit [f] c
      , Ring f
      , Scale a f

--- a/symbolic-base/src/ZkFold/Protocol/IVC/AccumulatorScheme.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/AccumulatorScheme.hs
@@ -12,6 +12,7 @@ import Data.Foldable (Foldable)
 import Data.Functor.Rep (Representable (..), mzipWithRep)
 import Data.Zip (Zip (..))
 import ZkFold.Algebra.Class
+import ZkFold.Algebra.EllipticCurve.Class (ScalarFieldOf)
 import ZkFold.Algebra.Number
 import ZkFold.Algebra.Polynomial.Univariate (polyVecLinear)
 import ZkFold.Algebra.Polynomial.Univariate.Simple (SimplePoly, toVector)
@@ -24,7 +25,7 @@ import ZkFold.Protocol.IVC.NARK (NARKInstanceProof (..), NARKProof (..))
 import ZkFold.Protocol.IVC.Oracle
 import ZkFold.Protocol.IVC.Predicate (Predicate)
 import ZkFold.Symbolic.Data.Class (LayoutData (LayoutData), layoutData)
-import Prelude (fmap, ($), (<$>))
+import Prelude (fmap, ($), (<$>), type (~))
 import qualified Prelude as P
 
 -- | Accumulator scheme for V_NARK as described in Chapter 3.4 of the Protostar paper
@@ -54,13 +55,14 @@ accumulatorScheme
      , Foldable p
      , OracleSource f f
      , OracleSource f c
-     , HomomorphicCommit [f] c
+     , HomomorphicCommit c
      , Field f
      , Scale a f
      , Scale a (SimplePoly f (d + 1))
      , Scale f c
      , Binary (Rep i)
      , Binary (Rep p)
+     , f ~ ScalarFieldOf c
      )
   => Hasher
   -> Predicate a i p

--- a/symbolic-base/src/ZkFold/Protocol/IVC/AccumulatorScheme.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/AccumulatorScheme.hs
@@ -11,9 +11,6 @@ import Data.Constraint.Nat (plusMinusInverse1)
 import Data.Foldable (Foldable)
 import Data.Functor.Rep (Representable (..), mzipWithRep)
 import Data.Zip (Zip (..))
-import Prelude (fmap, ($), (<$>))
-import qualified Prelude as P
-
 import ZkFold.Algebra.Class
 import ZkFold.Algebra.Number
 import ZkFold.Algebra.Polynomial.Univariate (polyVecLinear)
@@ -27,6 +24,8 @@ import ZkFold.Protocol.IVC.NARK (NARKInstanceProof (..), NARKProof (..))
 import ZkFold.Protocol.IVC.Oracle
 import ZkFold.Protocol.IVC.Predicate (Predicate)
 import ZkFold.Symbolic.Data.Class (LayoutData (LayoutData), layoutData)
+import Prelude (fmap, ($), (<$>))
+import qualified Prelude as P
 
 -- | Accumulator scheme for V_NARK as described in Chapter 3.4 of the Protostar paper
 data AccumulatorScheme d k i c f = AccumulatorScheme
@@ -51,6 +50,8 @@ accumulatorScheme
      , KnownNat (d + 1)
      , Representable i
      , Foldable i
+     , Representable p
+     , Foldable p
      , OracleSource f f
      , OracleSource f c
      , HomomorphicCommit [f] c
@@ -61,7 +62,9 @@ accumulatorScheme
      , Binary (Rep i)
      , Binary (Rep p)
      )
-  => Hasher -> Predicate a i p -> AccumulatorScheme d k i c f
+  => Hasher
+  -> Predicate a i p
+  -> AccumulatorScheme d k i c f
 accumulatorScheme hash phi =
   let
     prover acc (NARKInstanceProof pubi (NARKProof pi_x pi_w)) =

--- a/symbolic-base/src/ZkFold/Protocol/IVC/Commit.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/Commit.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module ZkFold.Protocol.IVC.Commit (
@@ -8,19 +5,17 @@ module ZkFold.Protocol.IVC.Commit (
   oracleCommitment,
   HomomorphicCommit (..),
   PedersonSetup (..),
-  PedersonCommit (..),
 ) where
 
+import Crypto.Hash.SHA256 (hash)
+import Data.Maybe (fromJust)
 import Data.Zip (Zip (..))
-import System.Random (Uniform, mkStdGen, uniform)
-import Prelude hiding (Num (..), sum, take, zipWith)
-
 import ZkFold.Algebra.Class
 import ZkFold.Algebra.EllipticCurve.Class
 import ZkFold.Algebra.Number
-import ZkFold.Data.Vector (Vector, unsafeToVector)
-import ZkFold.Prelude (take)
+import ZkFold.Data.ByteString (LittleEndian (..), fromByteString)
 import ZkFold.Protocol.IVC.Oracle
+import Prelude hiding (Num (..), sum, take, zipWith, (^))
 
 -- | Commit to the object @a@ with results of type @f@
 type Commit a f = a -> f
@@ -28,60 +23,24 @@ type Commit a f = a -> f
 oracleCommitment :: (OracleSource a b, Ring a) => Hasher -> Commit b a
 oracleCommitment = oracle
 
+class PedersonSetup g where
+  groupElements :: [g]
+
+instance
+  CyclicGroup g
+  => PedersonSetup g
+  where
+  groupElements =
+    -- TODO: This is just for testing purposes! Not to be used in production
+    let x = fromConstant @Natural $ unLittleEndian $ fromJust $ fromByteString $ hash "42" :: ScalarFieldOf g
+     in iterate (scale x) pointGen
+
 -- | Homomorphic commitment scheme, i.e. (hcommit x) * (hcommit y) == hcommit (x + y)
-class AdditiveGroup c => HomomorphicCommit a c where
-  hcommit :: a -> c
-
-class PedersonSetup s c where
-  groupElements :: s c
-
-type PedersonSetupMaxSize = 100
+class CyclicGroup g => HomomorphicCommit g where
+  hcommit :: [ScalarFieldOf g] -> g
 
 instance
-  ( CyclicGroup (Weierstrass curve (Point field))
-  , Uniform (ScalarFieldOf (Weierstrass curve (Point field)))
-  )
-  => PedersonSetup [] (Weierstrass curve (Point field))
+  CyclicGroup g
+  => HomomorphicCommit g
   where
-  groupElements =
-    -- TODO: This is just for testing purposes! Not to be used in production
-    let x = fst $ uniform $ mkStdGen 0 :: ScalarFieldOf (Weierstrass curve (Point field))
-     in take (value @PedersonSetupMaxSize) $ iterate (scale x) pointGen
-
-instance
-  ( KnownNat n
-  , CyclicGroup (Weierstrass curve (Point field))
-  , Uniform (ScalarFieldOf (Weierstrass curve (Point field)))
-  , n <= PedersonSetupMaxSize
-  )
-  => PedersonSetup (Vector n) (Weierstrass curve (Point field))
-  where
-  groupElements =
-    -- TODO: This is just for testing purposes! Not to be used in production
-    unsafeToVector $ take (value @n) $ groupElements @[]
-
-newtype PedersonCommit g = PedersonCommit {pedersonCommit :: g}
-  deriving newtype (AdditiveGroup, AdditiveMonoid, AdditiveSemigroup, Scale f)
-
-instance (Functor s, PedersonSetup s g) => PedersonSetup s (PedersonCommit g) where
-  groupElements = PedersonCommit <$> groupElements
-
-instance
-  ( PedersonSetup s g
-  , Zip s
-  , Foldable s
-  , Scale f g
-  , AdditiveGroup g
-  )
-  => HomomorphicCommit (s f) (PedersonCommit g)
-  where
-  hcommit v = sum $ zipWith scale v groupElements
-
-deriving via
-  (PedersonCommit (Weierstrass c (Point f)))
-  instance
-    ( CyclicGroup (Weierstrass c (Point f))
-    , Uniform (ScalarFieldOf (Weierstrass c (Point f)))
-    , Scale s (Weierstrass c (Point f))
-    )
-    => HomomorphicCommit [s] (Weierstrass c (Point f))
+  hcommit v = sum $ zipWith (scale @(ScalarFieldOf g)) v groupElements

--- a/symbolic-base/src/ZkFold/Protocol/IVC/CommitOpen.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/CommitOpen.hs
@@ -1,18 +1,20 @@
+{-# LANGUAGE TypeOperators #-}
+
 module ZkFold.Protocol.IVC.CommitOpen where
 
 import Data.Zip (zipWith)
-import Prelude hiding (Num (..), length, pi, tail, zipWith, (&&))
-
 import ZkFold.Algebra.Class (AdditiveGroup (..))
+import ZkFold.Algebra.EllipticCurve.Class (CyclicGroup (ScalarFieldOf))
 import ZkFold.Data.Vector (Vector)
 import ZkFold.Protocol.IVC.Commit (HomomorphicCommit (hcommit))
 import ZkFold.Protocol.IVC.SpecialSound (SpecialSoundProtocol (..))
+import Prelude hiding (Num (..), length, pi, tail, zipWith, (&&))
 
 type CommitOpen k i p c m o f =
   SpecialSoundProtocol k i p (m, c) (Vector k c, o) f
 
 commitOpen
-  :: (Functor i, Functor p, HomomorphicCommit m c)
+  :: (Functor i, Functor p, HomomorphicCommit c, m ~ [ScalarFieldOf c])
   => (a -> f)
   -> (f -> a)
   -> SpecialSoundProtocol k i p m o a

--- a/symbolic-base/src/ZkFold/Protocol/IVC/CommitOpen.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/CommitOpen.hs
@@ -14,21 +14,19 @@ type CommitOpen k i p c m o f =
   SpecialSoundProtocol k i p (m, c) (Vector k c, o) f
 
 commitOpen
-  :: (Functor i, Functor p, HomomorphicCommit c, m ~ [ScalarFieldOf c])
-  => (a -> f)
-  -> (f -> a)
-  -> SpecialSoundProtocol k i p m o a
-  -> CommitOpen k i p c m o f
-commitOpen af fa SpecialSoundProtocol {..} =
+  :: (HomomorphicCommit c, m ~ [ScalarFieldOf c])
+  => SpecialSoundProtocol k i p m o a
+  -> CommitOpen k i p c m o a
+commitOpen SpecialSoundProtocol {..} =
   SpecialSoundProtocol
-    { input = \i p -> af <$> input (fa <$> i) (fa <$> p)
+    { input = input
     , prover = \pi0 w r i ->
-        let m = prover (fmap fa pi0) (fmap fa w) (fa r) i
+        let m = prover pi0 w r i
          in (m, hcommit m)
     , verifier = \pi pms rs ->
         let ms = fmap fst pms
             cs = fmap snd pms
          in ( zipWith (-) (fmap hcommit ms) cs
-            , verifier (fmap fa pi) ms (fmap fa rs)
+            , verifier pi ms rs
             )
     }

--- a/symbolic-base/src/ZkFold/Protocol/IVC/CommitOpen.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/CommitOpen.hs
@@ -11,10 +11,7 @@ import ZkFold.Protocol.IVC.Commit (HomomorphicCommit (hcommit))
 import ZkFold.Protocol.IVC.SpecialSound (SpecialSoundProtocol (..))
 import Prelude hiding (Num (..), length, pi, tail, zipWith, (&&))
 
--- type CommitOpen k i p c m o f =
---   SpecialSoundProtocol k i p (m, c) (Vector k c, o) f
-
-data CommitOpen k i p c m o f = CommitOpen
+data CommitOpen k i p c f = CommitOpen
   { input
       :: i f
       -- \^ previous public input
@@ -31,23 +28,23 @@ data CommitOpen k i p c m o f = CommitOpen
       -- \^ current random challenge
       -> Natural
       -- \^ round number (starting from 1)
-      -> (m, c)
+      -> ([f], c)
   -- ^ prover message
   , verifier
       :: i f
       -- \^ public input
-      -> Vector k (m, c)
+      -> Vector k ([f], c)
       -- \^ prover messages
       -> Vector (k - 1) f
       -- \^ random challenges
-      -> (Vector k c, o)
+      -> (Vector k c, [f])
   -- ^ verifier output
   }
 
 commitOpen
-  :: (HomomorphicCommit c, m ~ [ScalarFieldOf c])
-  => SpecialSoundProtocol k i p m o a
-  -> CommitOpen k i p c m o a
+  :: (HomomorphicCommit c, f ~ ScalarFieldOf c)
+  => SpecialSoundProtocol k i p f
+  -> CommitOpen k i p c f
 commitOpen SpecialSoundProtocol {..} =
   CommitOpen
     { input = input

--- a/symbolic-base/src/ZkFold/Protocol/IVC/CommitOpen.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/CommitOpen.hs
@@ -5,20 +5,51 @@ module ZkFold.Protocol.IVC.CommitOpen where
 import Data.Zip (zipWith)
 import ZkFold.Algebra.Class (AdditiveGroup (..))
 import ZkFold.Algebra.EllipticCurve.Class (CyclicGroup (ScalarFieldOf))
+import ZkFold.Algebra.Number (Natural, type (-))
 import ZkFold.Data.Vector (Vector)
 import ZkFold.Protocol.IVC.Commit (HomomorphicCommit (hcommit))
 import ZkFold.Protocol.IVC.SpecialSound (SpecialSoundProtocol (..))
 import Prelude hiding (Num (..), length, pi, tail, zipWith, (&&))
 
-type CommitOpen k i p c m o f =
-  SpecialSoundProtocol k i p (m, c) (Vector k c, o) f
+-- type CommitOpen k i p c m o f =
+--   SpecialSoundProtocol k i p (m, c) (Vector k c, o) f
+
+data CommitOpen k i p c m o f = CommitOpen
+  { input
+      :: i f
+      -- \^ previous public input
+      -> p f
+      -- \^ witness
+      -> i f
+  -- ^ public input
+  , prover
+      :: i f
+      -- \^ previous public input
+      -> p f
+      -- \^ witness
+      -> f
+      -- \^ current random challenge
+      -> Natural
+      -- \^ round number (starting from 1)
+      -> (m, c)
+  -- ^ prover message
+  , verifier
+      :: i f
+      -- \^ public input
+      -> Vector k (m, c)
+      -- \^ prover messages
+      -> Vector (k - 1) f
+      -- \^ random challenges
+      -> (Vector k c, o)
+  -- ^ verifier output
+  }
 
 commitOpen
   :: (HomomorphicCommit c, m ~ [ScalarFieldOf c])
   => SpecialSoundProtocol k i p m o a
   -> CommitOpen k i p c m o a
 commitOpen SpecialSoundProtocol {..} =
-  SpecialSoundProtocol
+  CommitOpen
     { input = input
     , prover = \pi0 w r i ->
         let m = prover pi0 w r i

--- a/symbolic-base/src/ZkFold/Protocol/IVC/FiatShamir.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/FiatShamir.hs
@@ -5,23 +5,54 @@ module ZkFold.Protocol.IVC.FiatShamir where
 
 import Data.Constraint (withDict)
 import Data.Constraint.Nat (plusMinusInverse1)
-import Prelude hiding (Bool (..), Eq (..), init, length, pi, scanl, unzip)
-
 import ZkFold.Algebra.Class (Ring)
-import ZkFold.Algebra.Number (KnownNat, type (-))
-import ZkFold.Data.Vector (Vector, init, item, scanl, unfold)
+import ZkFold.Algebra.Number (KnownNat, Natural, type (-))
+import ZkFold.Data.Vector (Vector, init, scanl, unfold)
 import ZkFold.Protocol.IVC.CommitOpen
 import ZkFold.Protocol.IVC.Oracle
-import ZkFold.Protocol.IVC.SpecialSound (SpecialSoundProtocol (..))
+import Prelude hiding (Bool (..), Eq (..), init, length, pi, scanl, unzip)
 
-type FiatShamir k i p c m o f =
-  SpecialSoundProtocol 1 i p (Vector k (m, c)) (Vector k c, o) f
+-- type FiatShamir k i p c m o f =
+--   SpecialSoundProtocol 1 i p (Vector k (m, c)) (Vector k c, o) f
+
+data FiatShamir k i p c m o f = FiatShamir
+  { input
+      :: i f
+      -- \^ previous public input
+      -> p f
+      -- \^ witness
+      -> i f
+  -- ^ public input
+  , prover
+      :: i f
+      -- \^ previous public input
+      -> p f
+      -- \^ witness
+      -> f
+      -- \^ current random challenge
+      -> Natural
+      -- \^ round number (starting from 1)
+      -> Vector k (m, c)
+  -- ^ prover message
+  , verifier
+      :: i f
+      -- \^ public input
+      -> Vector k (m, c)
+      -- \^ prover messages
+      -> Vector (k - 1) f
+      -- \^ random challenges
+      -> (Vector k c, o)
+  -- ^ verifier output
+  }
 
 -- The transcript of the Fiat-Shamired protocol (ignoring the last round)
 transcript
   :: forall k c f
    . (Ring f, OracleSource f f, OracleSource f c)
-  => Hasher -> f -> Vector k c -> Vector (k - 1) f
+  => Hasher
+  -> f
+  -> Vector k c
+  -> Vector (k - 1) f
 transcript hash r0 cs =
   withDict (plusMinusInverse1 @1 @k) $
     init $
@@ -31,8 +62,10 @@ transcript hash r0 cs =
 fiatShamir
   :: forall k i p c m o f
    . (KnownNat k, Ring f, OracleSource f f, OracleSource f c, Foldable i)
-  => Hasher -> CommitOpen k i p c m o f -> FiatShamir k i p c m o f
-fiatShamir hash SpecialSoundProtocol {..} =
+  => Hasher
+  -> CommitOpen k i p c m o f
+  -> FiatShamir k i p c m o f
+fiatShamir hash CommitOpen {..} =
   let
     prover' pi0 w _ _ =
       let r0 = oracle hash (FoldableSource pi0)
@@ -41,10 +74,9 @@ fiatShamir hash SpecialSoundProtocol {..} =
              in ((m', c'), (oracle hash (r, c'), k + 1))
        in unfold f (r0, 1)
 
-    verifier' pi pms' _ =
-      let pms = item pms'
-          r0 = oracle hash (FoldableSource pi)
+    verifier' pi pms _ =
+      let r0 = oracle hash (FoldableSource pi)
           rs = transcript hash r0 $ fmap snd pms
        in verifier pi pms rs
    in
-    SpecialSoundProtocol input prover' verifier'
+    FiatShamir input prover' verifier'

--- a/symbolic-base/src/ZkFold/Protocol/IVC/FiatShamir.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/FiatShamir.hs
@@ -12,10 +12,7 @@ import ZkFold.Protocol.IVC.CommitOpen
 import ZkFold.Protocol.IVC.Oracle
 import Prelude hiding (Bool (..), Eq (..), init, length, pi, scanl, unzip)
 
--- type FiatShamir k i p c m o f =
---   SpecialSoundProtocol 1 i p (Vector k (m, c)) (Vector k c, o) f
-
-data FiatShamir k i p c m o f = FiatShamir
+data FiatShamir k i p c f = FiatShamir
   { input
       :: i f
       -- \^ previous public input
@@ -32,16 +29,16 @@ data FiatShamir k i p c m o f = FiatShamir
       -- \^ current random challenge
       -> Natural
       -- \^ round number (starting from 1)
-      -> Vector k (m, c)
+      -> Vector k ([f], c)
   -- ^ prover message
   , verifier
       :: i f
       -- \^ public input
-      -> Vector k (m, c)
+      -> Vector k ([f], c)
       -- \^ prover messages
       -> Vector (k - 1) f
       -- \^ random challenges
-      -> (Vector k c, o)
+      -> (Vector k c, [f])
   -- ^ verifier output
   }
 
@@ -60,11 +57,11 @@ transcript hash r0 cs =
         scanl (curry (oracle hash)) r0 cs
 
 fiatShamir
-  :: forall k i p c m o f
+  :: forall k i p c f
    . (KnownNat k, Ring f, OracleSource f f, OracleSource f c, Foldable i)
   => Hasher
-  -> CommitOpen k i p c m o f
-  -> FiatShamir k i p c m o f
+  -> CommitOpen k i p c f
+  -> FiatShamir k i p c f
 fiatShamir hash CommitOpen {..} =
   let
     prover' pi0 w _ _ =

--- a/symbolic-base/src/ZkFold/Protocol/IVC/ForeignField.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/ForeignField.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+module ZkFold.Protocol.IVC.ForeignField where
+
+import Data.Bool (otherwise)
+import ZkFold.Algebra.Class
+import ZkFold.Algebra.Field (Zp)
+import ZkFold.Algebra.Number (KnownNat, Natural, Prime, value)
+import ZkFold.Control.Conditional (Conditional (..))
+import ZkFold.Data.Eq (Eq (..))
+import ZkFold.Symbolic.MonadCircuit (IntegralOf, ResidueField, fromIntegral, toIntegral)
+import Prelude (Integer, Num (fromInteger), (<))
+
+newtype ForeignField q i = ForeignField {foreignField :: i}
+
+instance (KnownNat q, Euclidean i) => FromConstant Natural (ForeignField q i) where
+  fromConstant x = ForeignField (fromConstant x `mod` fromConstant (value @q))
+
+instance (KnownNat q, Euclidean i) => FromConstant Integer (ForeignField q i) where
+  fromConstant x = ForeignField (fromConstant x `mod` fromConstant (value @q))
+
+instance Eq i => Eq (ForeignField q i) where
+  type BooleanOf (ForeignField q i) = BooleanOf i
+  ForeignField f == ForeignField g = f == g
+  ForeignField f /= ForeignField g = f /= g
+
+deriving instance {-# INCOHERENT #-} Conditional b i => Conditional b (ForeignField q i)
+
+instance (KnownNat q, Euclidean i) => Scale Natural (ForeignField q i) where
+  scale k (ForeignField f) = ForeignField (scale k f `mod` fromConstant (value @q))
+
+instance (KnownNat q, Euclidean i) => Scale Integer (ForeignField q i) where
+  scale k (ForeignField f) = ForeignField (scale k f `mod` fromConstant (value @q))
+
+instance (KnownNat q, Euclidean i) => Exponent (ForeignField q i) Natural where
+  ForeignField f ^ p = ForeignField ((f ^ p) `mod` fromConstant (value @q))
+
+instance (KnownNat q, Euclidean i) => AdditiveSemigroup (ForeignField q i) where
+  ForeignField f + ForeignField g = ForeignField ((f + g) `mod` fromConstant (value @q))
+
+instance (KnownNat q, Euclidean i) => AdditiveMonoid (ForeignField q i) where
+  zero = ForeignField zero
+
+instance (KnownNat q, Euclidean i) => AdditiveGroup (ForeignField q i) where
+  negate (ForeignField f) = ForeignField (negate f `mod` fromConstant (value @q))
+  ForeignField f - ForeignField g = ForeignField ((f - g) `mod` fromConstant (value @q))
+
+instance (KnownNat q, Euclidean i) => MultiplicativeSemigroup (ForeignField q i) where
+  ForeignField f * ForeignField g = ForeignField ((f * g) `mod` fromConstant (value @q))
+
+instance (KnownNat q, Euclidean i) => MultiplicativeMonoid (ForeignField q i) where
+  one = ForeignField one
+
+instance (KnownNat q, Euclidean i) => Semiring (ForeignField q i)
+
+instance (KnownNat q, Euclidean i) => Ring (ForeignField q i)
+
+instance (KnownNat q, Euclidean i) => SemiEuclidean (ForeignField q i) where
+  ForeignField f `div` ForeignField g = ForeignField ((f `div` g) `mod` fromConstant (value @q))
+  ForeignField f `mod` ForeignField g = ForeignField ((f `mod` g) `mod` fromConstant (value @q))
+
+instance (KnownNat q, Euclidean i) => Euclidean (ForeignField q i) where
+  ForeignField f `gcd` ForeignField g = ForeignField ((f `gcd` g) `mod` fromConstant (value @q))
+  ForeignField f `bezoutL` ForeignField g = ForeignField ((f `bezoutL` g) `mod` fromConstant (value @q))
+  ForeignField f `bezoutR` ForeignField g = ForeignField ((f `bezoutR` g) `mod` fromConstant (value @q))
+
+instance (Prime q, Eq i, Euclidean i, Conditional (BooleanOf i) i) => Exponent (ForeignField q i) Integer where
+  ForeignField f ^ p
+    | p < 0 = finv (ForeignField f ^ (-p))
+    | otherwise = ForeignField ((f ^ (fromInteger p :: Natural)) `mod` fromConstant (value @q))
+
+instance (Prime q, Eq i, Euclidean i, Conditional (BooleanOf i) i) => Field (ForeignField q i) where
+  finv (ForeignField f) = ForeignField (f ^ (value @q -! 2) `mod` fromConstant (value @q))
+
+instance (KnownNat q, KnownNat (NumberOfBits (Zp q))) => Finite (ForeignField q i) where
+  type Order (ForeignField q i) = q
+
+instance
+  (Prime q, KnownNat (NumberOfBits (Zp q)), Eq i, Euclidean i, Conditional (BooleanOf i) i)
+  => ResidueField (ForeignField q i)
+  where
+  type IntegralOf (ForeignField q i) = i
+  fromIntegral i = ForeignField (i `mod` fromConstant (value @q))
+  toIntegral (ForeignField i) = i

--- a/symbolic-base/src/ZkFold/Protocol/IVC/ForeignField.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/ForeignField.hs
@@ -3,6 +3,7 @@
 module ZkFold.Protocol.IVC.ForeignField where
 
 import qualified Data.Eq as Haskell
+import GHC.Generics (Generic)
 import ZkFold.Algebra.Class
 import ZkFold.Algebra.Field (Zp)
 import ZkFold.Algebra.Number (KnownNat, Natural, Prime, value)
@@ -12,7 +13,7 @@ import ZkFold.Symbolic.MonadCircuit (IntegralOf, ResidueField, fromIntegral, toI
 import Prelude (Integer, Num (fromInteger))
 
 newtype ForeignField q i = ForeignField {foreignField :: i}
-  deriving Haskell.Eq
+  deriving (Generic, Haskell.Eq)
 
 instance (KnownNat q, Euclidean i) => FromConstant Natural (ForeignField q i) where
   fromConstant x = ForeignField (fromConstant x `mod` fromConstant (value @q))
@@ -75,7 +76,13 @@ instance (KnownNat q, KnownNat (NumberOfBits (Zp q))) => Finite (ForeignField q 
   type Order (ForeignField q i) = q
 
 instance
-  (Prime q, KnownNat (NumberOfBits (Zp q)), Eq i, Euclidean i, Conditional (BooleanOf i) i)
+  ( Prime q
+  , KnownNat (NumberOfBits (Zp q))
+  , Eq i
+  , Euclidean i
+  , Conditional (BooleanOf i) (BooleanOf i)
+  , Conditional (BooleanOf i) i
+  )
   => ResidueField (ForeignField q i)
   where
   type IntegralOf (ForeignField q i) = i

--- a/symbolic-base/src/ZkFold/Protocol/IVC/ForeignField.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/ForeignField.hs
@@ -2,6 +2,7 @@
 
 module ZkFold.Protocol.IVC.ForeignField where
 
+import qualified Data.Eq as Haskell
 import ZkFold.Algebra.Class
 import ZkFold.Algebra.Field (Zp)
 import ZkFold.Algebra.Number (KnownNat, Natural, Prime, value)
@@ -11,6 +12,7 @@ import ZkFold.Symbolic.MonadCircuit (IntegralOf, ResidueField, fromIntegral, toI
 import Prelude (Integer, Num (fromInteger))
 
 newtype ForeignField q i = ForeignField {foreignField :: i}
+  deriving Haskell.Eq
 
 instance (KnownNat q, Euclidean i) => FromConstant Natural (ForeignField q i) where
   fromConstant x = ForeignField (fromConstant x `mod` fromConstant (value @q))

--- a/symbolic-base/src/ZkFold/Protocol/IVC/Internal.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/Internal.hs
@@ -165,7 +165,7 @@ ivcProve hash f res witness =
             true
             (DataSource <$> pf)
 
-    protocol :: FiatShamir k (RecursiveI i) (RecursiveP d k i p c) (DataSource c) [a] [a] a
+    protocol :: FiatShamir k (RecursiveI i) (RecursiveP d k i p c) (DataSource c) a
     protocol =
       fiatShamir hash $
         commitOpen $
@@ -209,7 +209,7 @@ ivcVerify hash f res =
     accScheme :: AccumulatorScheme d k (RecursiveI i) (DataSource c) f
     accScheme = accumulatorScheme @d hash pRec
 
-    protocol :: FiatShamir k (RecursiveI i) (RecursiveP d k i p c) (DataSource c) [f] [f] f
+    protocol :: FiatShamir k (RecursiveI i) (RecursiveP d k i p c) (DataSource c) f
     protocol = fiatShamir hash $ commitOpen $ specialSoundProtocol' @d pRec
    in
     ( first (fmap dataSource) $ verifier protocol input (zip messages commits) zero

--- a/symbolic-base/src/ZkFold/Protocol/IVC/Internal.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/Internal.hs
@@ -16,6 +16,7 @@ import Data.Type.Equality (type (~))
 import Data.Zip (Zip (..), unzip)
 import GHC.Generics (Generic, Par1 (..), type (:*:) (..))
 import ZkFold.Algebra.Class
+import ZkFold.Algebra.EllipticCurve.Class (CyclicGroup (ScalarFieldOf))
 import ZkFold.Algebra.Number (KnownNat, type (+), type (-))
 import ZkFold.ArithmeticCircuit.Context (CircuitContext)
 import ZkFold.Data.Vector (Vector, singleton)
@@ -77,7 +78,8 @@ ivcSetup
      , LayoutFunctor i
      , LayoutFunctor p
      , FieldAssumptions a cc
-     , HomomorphicCommit [a] c
+     , HomomorphicCommit c
+     , a ~ ScalarFieldOf c
      )
   => Hasher
   -> StepFunction a i p
@@ -111,7 +113,8 @@ ivcProve
      , Layout c ~ f
      , fe ~ FieldElement (Interpreter a)
      , Scale fe c
-     , HomomorphicCommit [fe] c
+     , HomomorphicCommit c
+     , fe ~ ScalarFieldOf c
      )
   => Hasher
   -> StepFunction a i p

--- a/symbolic-base/src/ZkFold/Protocol/IVC/Internal.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/Internal.hs
@@ -19,19 +19,18 @@ import ZkFold.Algebra.Class
 import ZkFold.Algebra.EllipticCurve.Class (CyclicGroup (ScalarFieldOf))
 import ZkFold.Algebra.Number (KnownNat, type (+), type (-))
 import ZkFold.ArithmeticCircuit.Context (CircuitContext)
-import ZkFold.Data.Vector (Vector, singleton)
+import ZkFold.Data.Vector (Vector)
 import ZkFold.Protocol.IVC.Accumulator hiding (pi)
 import ZkFold.Protocol.IVC.AccumulatorScheme (AccumulatorScheme, accumulatorScheme)
 import qualified ZkFold.Protocol.IVC.AccumulatorScheme as Acc
 import ZkFold.Protocol.IVC.Commit (HomomorphicCommit)
-import ZkFold.Protocol.IVC.CommitOpen
+import ZkFold.Protocol.IVC.CommitOpen (commitOpen)
 import ZkFold.Protocol.IVC.FiatShamir
 import ZkFold.Protocol.IVC.NARK (NARKInstanceProof (..), NARKProof (..))
 import ZkFold.Protocol.IVC.Oracle
 import ZkFold.Protocol.IVC.Predicate (Predicate (..), StepFunction, predicate)
 import ZkFold.Protocol.IVC.RecursiveFunction
 import ZkFold.Protocol.IVC.SpecialSound (
-  SpecialSoundProtocol (..),
   specialSoundProtocol,
   specialSoundProtocol',
  )
@@ -213,6 +212,6 @@ ivcVerify hash f res =
     protocol :: FiatShamir k (RecursiveI i) (RecursiveP d k i p c) (DataSource c) [f] [f] f
     protocol = fiatShamir hash $ commitOpen $ specialSoundProtocol' @d pRec
    in
-    ( first (fmap dataSource) $ verifier protocol input (singleton $ zip messages commits) zero
+    ( first (fmap dataSource) $ verifier protocol input (zip messages commits) zero
     , bimap (fmap dataSource) dataSource $ Acc.decider accScheme (res ^. acc)
     )

--- a/symbolic-base/src/ZkFold/Protocol/IVC/Internal.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/Internal.hs
@@ -31,8 +31,8 @@ import ZkFold.Protocol.IVC.Oracle
 import ZkFold.Protocol.IVC.Predicate (Predicate (..), StepFunction, predicate)
 import ZkFold.Protocol.IVC.RecursiveFunction
 import ZkFold.Protocol.IVC.SpecialSound (
-  specialSoundProtocol,
-  specialSoundProtocol',
+  specialSoundProtocolA,
+  specialSoundProtocolC,
  )
 import ZkFold.Symbolic.Data.Bool (true)
 import ZkFold.Symbolic.Data.Class (Context, Layout, LayoutFunctor, SymbolicData, arithmetize)
@@ -169,7 +169,7 @@ ivcProve hash f res witness =
     protocol =
       fiatShamir hash $
         commitOpen $
-          specialSoundProtocol @d pRec
+          specialSoundProtocolA @d pRec
 
     (messages', commits') = unzip $ prover protocol input payload zero 0
 
@@ -210,7 +210,7 @@ ivcVerify hash f res =
     accScheme = accumulatorScheme @d hash pRec
 
     protocol :: FiatShamir k (RecursiveI i) (RecursiveP d k i p c) (DataSource c) f
-    protocol = fiatShamir hash $ commitOpen $ specialSoundProtocol' @d pRec
+    protocol = fiatShamir hash $ commitOpen $ specialSoundProtocolC @d pRec
    in
     ( first (fmap dataSource) $ verifier protocol input (zip messages commits) zero
     , bimap (fmap dataSource) dataSource $ Acc.decider accScheme (res ^. acc)

--- a/symbolic-base/src/ZkFold/Protocol/IVC/Internal.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/Internal.hs
@@ -15,7 +15,6 @@ import Data.Functor (Functor, fmap, (<$>))
 import Data.Type.Equality (type (~))
 import Data.Zip (Zip (..), unzip)
 import GHC.Generics (Generic, Par1 (..), type (:*:) (..))
-
 import ZkFold.Algebra.Class
 import ZkFold.Algebra.Number (KnownNat, type (+), type (-))
 import ZkFold.ArithmeticCircuit.Context (CircuitContext)

--- a/symbolic-base/src/ZkFold/Protocol/IVC/NARK.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/NARK.hs
@@ -5,12 +5,10 @@ module ZkFold.Protocol.IVC.NARK where
 import Control.DeepSeq (NFData (..))
 import Data.Zip (unzip)
 import GHC.Generics
-import Prelude hiding (head, length, pi, unzip)
-
 import ZkFold.Algebra.Class (Ring, zero)
 import ZkFold.Data.Vector (Vector)
-import ZkFold.Protocol.IVC.FiatShamir (FiatShamir)
-import ZkFold.Protocol.IVC.SpecialSound (SpecialSoundProtocol (..))
+import ZkFold.Protocol.IVC.FiatShamir (FiatShamir (..))
+import Prelude hiding (head, length, pi, unzip)
 
 -- Page 18, section 3.4, The accumulation predicate
 data NARKProof k c f = NARKProof

--- a/symbolic-base/src/ZkFold/Protocol/IVC/NARK.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/NARK.hs
@@ -19,7 +19,7 @@ data NARKProof k c f = NARKProof
 
 narkProof
   :: Ring f
-  => FiatShamir k i p c [f] o f
+  => FiatShamir k i p c f
   -> i f
   -> p f
   -> NARKProof k c f
@@ -32,7 +32,7 @@ data NARKInstanceProof k i c f = NARKInstanceProof (i f) (NARKProof k c f)
 
 narkInstanceProof
   :: Ring f
-  => FiatShamir k i p c [f] o f
+  => FiatShamir k i p c f
   -> i f
   -> p f
   -> NARKInstanceProof k i c f

--- a/symbolic-base/src/ZkFold/Protocol/IVC/OperationRecord.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/OperationRecord.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE TypeOperators #-}
+
+module ZkFold.Protocol.IVC.OperationRecord where
+
+import Data.Either (Either (..))
+import ZkFold.Algebra.Class
+import ZkFold.Protocol.IVC.Commit (HomomorphicCommit (..))
+import ZkFold.Symbolic.Data.Class (SymbolicData (..), withoutConstraints)
+import ZkFold.Symbolic.Data.List (List, head, (.:))
+import ZkFold.Symbolic.Data.Sum (OneOf, embedOneOf, matchOneOf, zeroed)
+import Prelude (($), type (~))
+
+newtype OperationRecord c s ctx = OperationRecord (List ctx (OneOf [(c, c, c), (c, s, c)] ctx))
+
+addOp
+  :: (SymbolicData c, SymbolicData s, Context c ~ ctx, Context s ~ ctx, HomomorphicCommit [s] c, Scale s c)
+  => OneOf [c, s] ctx
+  -> OperationRecord c s ctx
+  -> OperationRecord c s ctx
+addOp op' (OperationRecord ops) =
+  let c =
+        matchOneOf
+          (head ops)
+          ( \case
+              Left (_, _, c1) -> c1
+              Right (Left (_, _, c1)) -> c1
+              Right (Right _) -> zeroed
+          )
+   in OperationRecord $
+        matchOneOf
+          op'
+          ( \case
+              Left c' -> embedOneOf $ Left (c, c', withoutConstraints $ c + c')
+              Right (Left s) -> embedOneOf $ Right $ Left (c, s, withoutConstraints $ scale s c)
+              Right (Right _) -> zeroed
+          )
+          .: ops

--- a/symbolic-base/src/ZkFold/Protocol/IVC/OperationRecord.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/OperationRecord.hs
@@ -1,16 +1,32 @@
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module ZkFold.Protocol.IVC.OperationRecord where
 
 import Data.Either (Either (..))
+import Data.List (foldr, map, zipWith)
+import GHC.Generics (Generic)
 import ZkFold.Algebra.Class
-import ZkFold.Protocol.IVC.Commit (HomomorphicCommit (..))
+import ZkFold.Algebra.Number (Natural)
+import ZkFold.Protocol.IVC.Commit (HomomorphicCommit (..), PedersonSetup (groupElements))
 import ZkFold.Symbolic.Data.Class (SymbolicData (..), withoutConstraints)
-import ZkFold.Symbolic.Data.List (List, head, (.:))
+import ZkFold.Symbolic.Data.List (List, emptyList, head, (.:))
 import ZkFold.Symbolic.Data.Sum (OneOf, embedOneOf, matchOneOf, zeroed)
-import Prelude (($), type (~))
+import Prelude (Integer, ($), type (~))
 
 newtype OperationRecord c s ctx = OperationRecord (List ctx (OneOf [(c, c, c), (c, s, c)] ctx))
+  deriving Generic
+
+instance
+  (SymbolicData c, SymbolicData s, Context c ~ ctx, Context s ~ ctx)
+  => SymbolicData (OperationRecord c s ctx)
+
+newRec
+  :: (SymbolicData c, SymbolicData s, Context c ~ ctx, Context s ~ ctx)
+  => c
+  -> OperationRecord c s ctx
+newRec c = OperationRecord $ embedOneOf (Left (c, c, c)) .: emptyList
 
 addOp
   :: (SymbolicData c, SymbolicData s, Context c ~ ctx, Context s ~ ctx, HomomorphicCommit [s] c, Scale s c)
@@ -22,8 +38,8 @@ addOp op' (OperationRecord ops) =
         matchOneOf
           (head ops)
           ( \case
-              Left (_, _, c1) -> c1
-              Right (Left (_, _, c1)) -> c1
+              Left (_, _, x) -> x
+              Right (Left (_, _, x)) -> x
               Right (Right _) -> zeroed
           )
    in OperationRecord $
@@ -31,3 +47,92 @@ addOp op' (OperationRecord ops) =
           Left c' -> embedOneOf $ Left (c, c', withoutConstraints $ c + c')
           Right s -> embedOneOf $ Right $ Left (c, s, withoutConstraints $ scale s c)
           .: ops
+
+instance
+  (HomomorphicCommit [s] c, Scale s c, SymbolicData c, Context c ~ ctx, SymbolicData s, Context s ~ ctx)
+  => AdditiveSemigroup (OperationRecord c s ctx)
+  where
+  OperationRecord ops + record =
+    let c =
+          matchOneOf
+            (head ops)
+            ( \case
+                Left (_, _, x) -> x
+                Right (Left (_, _, x)) -> x
+                Right (Right _) -> zeroed
+            )
+     in addOp (Left c) record
+
+instance
+  ( HomomorphicCommit [s] c
+  , Scale s c
+  , SymbolicData c
+  , Context c ~ ctx
+  , SymbolicData s
+  , Context s ~ ctx
+  , FromConstant Natural s
+  )
+  => AdditiveMonoid (OperationRecord c s ctx)
+  where
+  zero = newRec zero
+
+instance
+  ( HomomorphicCommit [s] c
+  , Scale s c
+  , SymbolicData c
+  , Context c ~ ctx
+  , SymbolicData s
+  , Context s ~ ctx
+  , FromConstant Natural s
+  , FromConstant Integer s
+  )
+  => AdditiveGroup (OperationRecord c s ctx)
+  where
+  negate = scale (-1 :: Integer)
+
+instance
+  (HomomorphicCommit [s] c, Scale s c, SymbolicData c, Context c ~ ctx, SymbolicData s, Context s ~ ctx)
+  => Scale s (OperationRecord c s ctx)
+  where
+  scale s = addOp (Right s)
+
+instance
+  ( HomomorphicCommit [s] c
+  , Scale s c
+  , SymbolicData c
+  , Context c ~ ctx
+  , SymbolicData s
+  , Context s ~ ctx
+  , FromConstant Natural s
+  )
+  => Scale Natural (OperationRecord c s ctx)
+  where
+  scale n = addOp (Right $ fromConstant n)
+
+instance
+  ( HomomorphicCommit [s] c
+  , Scale s c
+  , SymbolicData c
+  , Context c ~ ctx
+  , SymbolicData s
+  , Context s ~ ctx
+  , FromConstant Integer s
+  )
+  => Scale Integer (OperationRecord c s ctx)
+  where
+  scale n = addOp (Right $ fromConstant n)
+
+instance
+  ( PedersonSetup [] (OperationRecord c s ctx)
+  , HomomorphicCommit [s] c
+  , Scale s c
+  , SymbolicData c
+  , Context c ~ ctx
+  , SymbolicData s
+  , Context s ~ ctx
+  , FromConstant Natural s
+  , FromConstant Integer s
+  )
+  => HomomorphicCommit [s] (OperationRecord c s ctx)
+  where
+  hcommit ops = foldr (+) zero $ zipWith scale ops $ map withoutConstraints $ groupElements @[] @(OperationRecord c s ctx)

--- a/symbolic-base/src/ZkFold/Protocol/IVC/OperationRecord.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/OperationRecord.hs
@@ -14,7 +14,7 @@ newtype OperationRecord c s ctx = OperationRecord (List ctx (OneOf [(c, c, c), (
 
 addOp
   :: (SymbolicData c, SymbolicData s, Context c ~ ctx, Context s ~ ctx, HomomorphicCommit [s] c, Scale s c)
-  => OneOf [c, s] ctx
+  => Either c s
   -> OperationRecord c s ctx
   -> OperationRecord c s ctx
 addOp op' (OperationRecord ops) =
@@ -27,11 +27,7 @@ addOp op' (OperationRecord ops) =
               Right (Right _) -> zeroed
           )
    in OperationRecord $
-        matchOneOf
-          op'
-          ( \case
-              Left c' -> embedOneOf $ Left (c, c', withoutConstraints $ c + c')
-              Right (Left s) -> embedOneOf $ Right $ Left (c, s, withoutConstraints $ scale s c)
-              Right (Right _) -> zeroed
-          )
+        case op' of
+          Left c' -> embedOneOf $ Left (c, c', withoutConstraints $ c + c')
+          Right s -> embedOneOf $ Right $ Left (c, s, withoutConstraints $ scale s c)
           .: ops

--- a/symbolic-base/src/ZkFold/Protocol/IVC/Oracle.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/Oracle.hs
@@ -7,7 +7,6 @@ import Data.Foldable (Foldable, foldMap)
 import Data.Function ((.))
 import Data.List ((++))
 import GHC.Generics
-
 import ZkFold.Algebra.Class
 import ZkFold.Algorithm.Hash.MiMC (mimcConstants, mimcHashN)
 import ZkFold.Data.Vector (Vector)
@@ -24,6 +23,9 @@ class OracleSource a b where
   -- ^ Extracts random seed from the source.
   default source :: (Generic b, GOracleSource a (Rep b)) => b -> [a]
   source = gsource . from
+
+instance {-# INCOHERENT #-} OracleSource a a where
+  source a = [a]
 
 instance
   (OracleSource a b, OracleSource a c)

--- a/symbolic-base/src/ZkFold/Protocol/IVC/RecursiveFunction.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/RecursiveFunction.hs
@@ -11,9 +11,8 @@ import Data.Binary (Binary (..))
 import Data.Foldable (toList)
 import Data.Function ((.))
 import GHC.Generics (Generic, Par1, (:*:))
-import Prelude ((<$>), type (~))
-
 import ZkFold.Algebra.Class
+import ZkFold.Algebra.EllipticCurve.Class (CyclicGroup (..))
 import ZkFold.Algebra.Number (KnownNat, type (+), type (-))
 import ZkFold.ArithmeticCircuit.Context (CircuitContext)
 import ZkFold.Data.Empty (Empty, empty)
@@ -29,6 +28,7 @@ import ZkFold.Symbolic.Class (Arithmetic)
 import ZkFold.Symbolic.Data.Bool (Bool, bool)
 import ZkFold.Symbolic.Data.Class (LayoutFunctor, SymbolicData (..))
 import ZkFold.Symbolic.Data.FieldElement (FieldElement (..), fieldElements)
+import Prelude ((<$>), type (~))
 
 -- | Public input to the recursive function
 type RecursiveI i = i :*: Par1
@@ -38,10 +38,11 @@ newtype DataSource c = DataSource {dataSource :: c}
     ( AdditiveGroup
     , AdditiveMonoid
     , AdditiveSemigroup
-    , HomomorphicCommit h
-    , Scale a
+    , CyclicGroup
     , SymbolicData
     )
+
+deriving instance {-# INCOHERENT #-} Scale a c => Scale a (DataSource c)
 
 instance
   (SymbolicData c, Context c ~ ctx)
@@ -55,10 +56,10 @@ data RecursivePayload d k i p c = RecursivePayload
   , recProof :: Vector k (DataSource c)
   , recAccInst
       :: AccumulatorInstance
-           k
-           (RecursiveI i)
-           (DataSource c)
-           (FieldElement (Context c))
+          k
+          (RecursiveI i)
+          (DataSource c)
+          (FieldElement (Context c))
   , recFlag :: Bool (Context c)
   , recCommits :: Vector (d - 1) (DataSource c)
   }
@@ -86,7 +87,8 @@ type FieldAssumptions a c =
   , Context c ~ CircuitContext a
   , Empty (Payload c)
   , Scale (FieldElement (Context c)) c
-  , HomomorphicCommit [FieldElement (Context c)] c
+  , HomomorphicCommit c
+  , FieldElement (Context c) ~ ScalarFieldOf c
   )
 
 instance OracleSource (FieldElement ctx) (FieldElement ctx) where
@@ -129,10 +131,10 @@ recursiveFunction hash func =
    in
     \i
      ( restore0 ->
-         ( RecursivePayload u piX accX flag pf
-             :: RecursivePayload d k i p c
-           )
-       ) ->
+        ( RecursivePayload u piX accX flag pf
+            :: RecursivePayload d k i p c
+          )
+      ) ->
         let z = FieldElement <$> unpacked i
             (x, _ :: FieldElement (Context c)) = restore0 i
             accX' = verifier (accumulatorScheme hash pRec) z piX accX pf

--- a/symbolic-base/src/ZkFold/Protocol/IVC/SpecialSound.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/SpecialSound.hs
@@ -30,7 +30,7 @@ and checks that the output is a zero vector of length l.
 
 --}
 
-data SpecialSoundProtocol k i p m o f = SpecialSoundProtocol
+data SpecialSoundProtocol k i p f = SpecialSoundProtocol
   { input
       :: i f
       -- \^ previous public input
@@ -47,16 +47,16 @@ data SpecialSoundProtocol k i p m o f = SpecialSoundProtocol
       -- \^ current random challenge
       -> Natural
       -- \^ round number (starting from 1)
-      -> m
+      -> [f]
   -- ^ prover message
   , verifier
       :: i f
       -- \^ public input
-      -> Vector k m
+      -> Vector k [f]
       -- \^ prover messages
       -> Vector (k - 1) f
       -- \^ random challenges
-      -> o
+      -> [f]
   -- ^ verifier output
   }
 
@@ -72,7 +72,7 @@ specialSoundProtocol
      , Foldable p
      )
   => Predicate a i p
-  -> SpecialSoundProtocol 1 i p [a] [a] a
+  -> SpecialSoundProtocol 1 i p a
 specialSoundProtocol phi@Predicate {..} =
   let
     prover pi0 w _ _ =
@@ -98,7 +98,7 @@ specialSoundProtocol'
      , Scale a f
      )
   => Predicate a i p
-  -> SpecialSoundProtocol 1 i p [f] [f] f
+  -> SpecialSoundProtocol 1 i p f
 specialSoundProtocol' phi =
   let
     verifier pi pm ts = AM.algebraicMap @d phi pi pm ts one

--- a/symbolic-base/src/ZkFold/Protocol/IVC/WeierstrassWitness.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/WeierstrassWitness.hs
@@ -5,7 +5,8 @@
 
 module ZkFold.Protocol.IVC.WeierstrassWitness where
 
-import Data.Function (($))
+import Data.Foldable (toList)
+import Data.Function (($), (.))
 import Data.String (fromString)
 import GHC.Generics (Generic, U1 (..))
 import ZkFold.Algebra.Class (
@@ -27,6 +28,7 @@ import ZkFold.Data.Bool (BoolType)
 import ZkFold.Data.Eq (Eq (..))
 import ZkFold.Data.Vector (Vector, unsafeToVector, (!!))
 import ZkFold.Protocol.IVC.ForeignField (ForeignField)
+import ZkFold.Protocol.IVC.Oracle (OracleSource (..))
 import ZkFold.Symbolic.Class (Symbolic (..))
 import ZkFold.Symbolic.Data.Class (SymbolicData (..))
 import ZkFold.Symbolic.MonadCircuit (IntegralOf, ResidueField (..))
@@ -70,6 +72,9 @@ instance
           )
       )
   interpolate _ _ = error "Interpolation is not defined for WeierstrassWitness"
+
+instance (SymbolicData (WeierstrassWitness ctx), w ~ WitnessField ctx) => OracleSource w (WeierstrassWitness ctx) where
+  source = toList . payload
 
 instance
   ( Symbolic ctx

--- a/symbolic-base/src/ZkFold/Protocol/IVC/WeierstrassWitness.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/WeierstrassWitness.hs
@@ -162,14 +162,14 @@ instance
   )
   => Scale w (WeierstrassWitness ctx)
   where
-  scale w p =
+  scale w x =
     if n == zero
       then zero
       else
-        scale (fromIntegral @w $ n `div` two) (p + p)
+        scale (fromIntegral @w $ n `div` two) (x + x)
           + if n `mod` two == zero
             then zero
-            else p
+            else x
    where
     n = toIntegral w
     two = one + one

--- a/symbolic-base/src/ZkFold/Protocol/IVC/WeierstrassWitness.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/WeierstrassWitness.hs
@@ -1,0 +1,173 @@
+{-# LANGUAGE RebindableSyntax #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module ZkFold.Protocol.IVC.WeierstrassWitness where
+
+import Data.Function (($))
+import GHC.Generics (Generic)
+import ZkFold.Algebra.Class (
+  AdditiveGroup (..),
+  AdditiveMonoid (..),
+  AdditiveSemigroup (..),
+  MultiplicativeMonoid (..),
+  Scale (..),
+  SemiEuclidean (..),
+  fromConstant,
+ )
+import ZkFold.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Base)
+import ZkFold.Algebra.EllipticCurve.Class (CyclicGroup (..), Planar, Point, Weierstrass, pointXY)
+import ZkFold.Algebra.Number (Natural)
+import ZkFold.Control.Conditional (Conditional (..), ifThenElse)
+import ZkFold.Data.Bool (BoolType)
+import ZkFold.Data.Eq (Eq (..))
+import ZkFold.Protocol.IVC.ForeignField (ForeignField)
+import ZkFold.Symbolic.Class (Symbolic (..))
+import ZkFold.Symbolic.MonadCircuit (IntegralOf, ResidueField (..))
+import Prelude (Integer, fromInteger, type (~))
+
+newtype WeierstrassWitness ctx
+  = WeierstrassWitness (Weierstrass "BLS12-381-G1" (Point (ForeignField BLS12_381_Base (IntegralOf (WitnessField ctx)))))
+  deriving Generic
+
+instance
+  ( Symbolic ctx
+  , BoolType (BooleanOf (IntegralOf (WitnessField ctx)))
+  , Conditional (BooleanOf (IntegralOf (WitnessField ctx))) (BooleanOf (IntegralOf (WitnessField ctx)))
+  , Conditional (BooleanOf (IntegralOf (WitnessField ctx))) (IntegralOf (WitnessField ctx))
+  )
+  => Eq (WeierstrassWitness ctx)
+  where
+  type
+    BooleanOf (WeierstrassWitness ctx) =
+      BooleanOf (Weierstrass "BLS12-381-G1" (Point (ForeignField BLS12_381_Base (IntegralOf (WitnessField ctx)))))
+  WeierstrassWitness p1 == WeierstrassWitness p2 = p1 == p2
+  WeierstrassWitness p1 /= WeierstrassWitness p2 = p1 /= p2
+
+instance
+  ( Symbolic ctx
+  , BoolType b
+  , Conditional b (Weierstrass "BLS12-381-G1" (Point (ForeignField BLS12_381_Base (IntegralOf (WitnessField ctx)))))
+  , b ~ BooleanOf (IntegralOf (WitnessField ctx))
+  )
+  => Conditional b (WeierstrassWitness ctx)
+  where
+  bool (WeierstrassWitness p1) (WeierstrassWitness p2) b =
+    WeierstrassWitness (bool p1 p2 b)
+
+instance
+  ( Symbolic ctx
+  , Conditional b (IntegralOf (WitnessField ctx))
+  , Conditional b (Weierstrass "BLS12-381-G1" (Point (ForeignField BLS12_381_Base (IntegralOf (WitnessField ctx)))))
+  , b ~ BooleanOf (IntegralOf (WitnessField ctx))
+  )
+  => AdditiveSemigroup (WeierstrassWitness ctx)
+  where
+  WeierstrassWitness p1 + WeierstrassWitness p2 =
+    WeierstrassWitness (p1 + p2)
+
+instance
+  ( Symbolic ctx
+  , Conditional b (IntegralOf (WitnessField ctx))
+  , Conditional b (Weierstrass "BLS12-381-G1" (Point (ForeignField BLS12_381_Base (IntegralOf (WitnessField ctx)))))
+  , Conditional b b
+  , b ~ BooleanOf (IntegralOf (WitnessField ctx))
+  , Scale Natural (WeierstrassWitness ctx)
+  )
+  => AdditiveMonoid (WeierstrassWitness ctx)
+  where
+  zero = WeierstrassWitness zero
+
+instance
+  ( Symbolic ctx
+  , Conditional (BooleanOf (IntegralOf (WitnessField ctx))) (IntegralOf (WitnessField ctx))
+  , Conditional b (Weierstrass "BLS12-381-G1" (Point (ForeignField BLS12_381_Base (IntegralOf (WitnessField ctx)))))
+  , Conditional b b
+  , b ~ BooleanOf (IntegralOf (WitnessField ctx))
+  , Scale Natural (WeierstrassWitness ctx)
+  , Scale Integer (WeierstrassWitness ctx)
+  )
+  => AdditiveGroup (WeierstrassWitness ctx)
+  where
+  negate (WeierstrassWitness p) =
+    WeierstrassWitness (negate p)
+
+instance
+  ( Symbolic ctx
+  , Conditional (BooleanOf (IntegralOf (WitnessField ctx))) (IntegralOf (WitnessField ctx))
+  , Conditional b (Weierstrass "BLS12-381-G1" (Point (ForeignField BLS12_381_Base (IntegralOf (WitnessField ctx)))))
+  , Conditional b b
+  , b ~ BooleanOf (IntegralOf (WitnessField ctx))
+  )
+  => Scale Natural (WeierstrassWitness ctx)
+  where
+  scale n (WeierstrassWitness p) =
+    WeierstrassWitness (scale n p)
+
+instance
+  ( Symbolic ctx
+  , Conditional (BooleanOf (IntegralOf (WitnessField ctx))) (IntegralOf (WitnessField ctx))
+  , Conditional b (Weierstrass "BLS12-381-G1" (Point (ForeignField BLS12_381_Base (IntegralOf (WitnessField ctx)))))
+  , Conditional b b
+  , b ~ BooleanOf (IntegralOf (WitnessField ctx))
+  )
+  => Scale Integer (WeierstrassWitness ctx)
+  where
+  scale n (WeierstrassWitness p) =
+    WeierstrassWitness (scale n p)
+
+instance
+  ( Symbolic ctx
+  , f ~ ForeignField BLS12_381_Base (IntegralOf (WitnessField ctx))
+  )
+  => Planar f (WeierstrassWitness ctx)
+  where
+  pointXY x y =
+    WeierstrassWitness (pointXY x y)
+
+instance
+  ( Symbolic ctx
+  , Conditional (BooleanOf (IntegralOf (WitnessField ctx))) (IntegralOf (WitnessField ctx))
+  , Conditional b (Weierstrass "BLS12-381-G1" (Point (ForeignField BLS12_381_Base (IntegralOf (WitnessField ctx)))))
+  , Conditional b b
+  , b ~ BooleanOf (IntegralOf (WitnessField ctx))
+  , Scale Natural (WeierstrassWitness ctx)
+  , Scale Integer (WeierstrassWitness ctx)
+  , Scale (WitnessField ctx) (WeierstrassWitness ctx)
+  )
+  => CyclicGroup (WeierstrassWitness ctx)
+  where
+  type
+    ScalarFieldOf (WeierstrassWitness ctx) =
+      WitnessField ctx
+  pointGen =
+    pointXY @(ForeignField BLS12_381_Base (IntegralOf (WitnessField ctx)))
+      ( fromConstant @Natural 0x17f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb
+      )
+      ( fromConstant @Natural 0x8b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e1
+      )
+
+instance
+  ( Symbolic ctx
+  , Conditional (BooleanOf (IntegralOf (WitnessField ctx))) (IntegralOf (WitnessField ctx))
+  , Conditional b (Weierstrass "BLS12-381-G1" (Point (ForeignField BLS12_381_Base (IntegralOf (WitnessField ctx)))))
+  , Conditional b b
+  , b ~ BooleanOf (IntegralOf (WitnessField ctx))
+  , w ~ WitnessField ctx
+  , n ~ IntegralOf w
+  , Scale Natural (WeierstrassWitness ctx)
+  )
+  => Scale w (WeierstrassWitness ctx)
+  where
+  scale w p =
+    if n == zero
+      then p
+      else
+        scale (fromIntegral @w $ n `div` two) (p + p)
+          + if n `mod` two == zero
+            then zero
+            else p
+   where
+    n = toIntegral w
+    two = one + one

--- a/symbolic-base/src/ZkFold/Protocol/IVC/WeierstrassWitness.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/WeierstrassWitness.hs
@@ -94,6 +94,7 @@ instance
     WeierstrassWitness (negate p)
 
 instance
+  {-# OVERLAPPING #-}
   ( Symbolic ctx
   , Conditional (BooleanOf (IntegralOf (WitnessField ctx))) (IntegralOf (WitnessField ctx))
   , Conditional b (Weierstrass "BLS12-381-G1" (Point (ForeignField BLS12_381_Base (IntegralOf (WitnessField ctx)))))
@@ -106,6 +107,7 @@ instance
     WeierstrassWitness (scale n p)
 
 instance
+  {-# OVERLAPPING #-}
   ( Symbolic ctx
   , Conditional (BooleanOf (IntegralOf (WitnessField ctx))) (IntegralOf (WitnessField ctx))
   , Conditional b (Weierstrass "BLS12-381-G1" (Point (ForeignField BLS12_381_Base (IntegralOf (WitnessField ctx)))))
@@ -162,7 +164,7 @@ instance
   where
   scale w p =
     if n == zero
-      then p
+      then zero
       else
         scale (fromIntegral @w $ n `div` two) (p + p)
           + if n `mod` two == zero

--- a/symbolic-base/src/ZkFold/Protocol/Plonkup/Relation.hs
+++ b/symbolic-base/src/ZkFold/Protocol/Plonkup/Relation.hs
@@ -26,8 +26,6 @@ import GHC.Generics (Par1 (..), (:*:) (..))
 import GHC.IsList (fromList)
 import Test.QuickCheck (Arbitrary (..))
 import Text.Show (Show (..))
-import qualified Prelude as P
-
 import ZkFold.Algebra.Class
 import ZkFold.Algebra.Number
 import ZkFold.Algebra.Permutation (Permutation, fromCycles, mkIndexPartition)
@@ -47,6 +45,7 @@ import ZkFold.Protocol.Plonkup.PlonkConstraint (PlonkConstraint (..), toPlonkCon
 import ZkFold.Protocol.Plonkup.PlonkupConstraint
 import ZkFold.Symbolic.Class (Arithmetic)
 import ZkFold.Symbolic.MonadCircuit (ResidueField (..))
+import qualified Prelude as P
 
 -- Here `n` is the total number of constraints, `i` is the number of inputs to the circuit, and `a` is the field type.
 data PlonkupRelation i o n a pv = PlonkupRelation
@@ -152,7 +151,10 @@ instance Euclidean a => Euclidean (Vector a) where
 instance Finite a => Finite (Vector a) where
   type Order (Vector a) = Order a
 
-instance (ResidueField a, Conditional (BooleanOf a) (Vector a)) => ResidueField (Vector a) where
+instance
+  (ResidueField a, Conditional (BooleanOf a) (Vector a), Conditional (BooleanOf (IntegralOf a)) (Vector (IntegralOf a)))
+  => ResidueField (Vector a)
+  where
   type IntegralOf (Vector a) = Vector (IntegralOf a)
   fromIntegral = fmap fromIntegral
   toIntegral = fmap toIntegral
@@ -175,7 +177,8 @@ toPlonkupRelation
      , Representable o
      , Foldable o
      )
-  => ArithmeticCircuit a i o -> Maybe (PlonkupRelation i o n a pv)
+  => ArithmeticCircuit a i o
+  -> Maybe (PlonkupRelation i o n a pv)
 toPlonkupRelation !ac =
   let !n = value @n
 

--- a/symbolic-base/src/ZkFold/Symbolic/Class.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Class.hs
@@ -11,11 +11,10 @@ import Data.Function ((.))
 import Data.Functor ((<$>))
 import Data.Kind (Type)
 import Data.Ord (Ord)
+import Data.Traversable (traverse)
 import Data.Type.Equality (type (~))
 import GHC.Generics (type (:.:) (unComp1))
 import Numeric.Natural (Natural)
-import Prelude (Enum, Integer)
-
 import ZkFold.Algebra.Class
 import ZkFold.Control.HApplicative (HApplicative (hpair, hunit))
 import ZkFold.Data.Eq (BooleanOf)
@@ -23,6 +22,7 @@ import ZkFold.Data.HFunctor.Classes (HNFData)
 import ZkFold.Data.Package (Package (pack))
 import ZkFold.Data.Product (uncurryP)
 import ZkFold.Symbolic.MonadCircuit
+import Prelude (Enum, Integer, Traversable)
 
 -- | Field of residues with decidable equality and ordering
 -- is called an ``arithmetic'' field.
@@ -89,6 +89,10 @@ class
 embed :: (Symbolic c, Functor f) => f (BaseField c) -> c f
 embed cs = fromCircuitF hunit (\_ -> return (fromConstant <$> cs))
 
+-- | Embeds the witness value(s) into generic context @c@.
+embedW :: (Symbolic c, Traversable f) => f (WitnessField c) -> c f
+embedW ws = fromCircuitF hunit (\_ -> traverse unconstrained ws)
+
 symbolicF
   :: (Symbolic c, BaseField c ~ a)
   => c f
@@ -143,7 +147,9 @@ symbolicVF xs f m = symbolicF (pack xs) (f . unComp1) (m . unComp1)
 
 fromCircuitVF
   :: (Symbolic c, BaseField c ~ a, WitnessField c ~ w, Foldable f, Functor f)
-  => f (c g) -> (forall i m. MonadCircuit i a w m => f (g i) -> m (h i)) -> c h
+  => f (c g)
+  -> (forall i m. MonadCircuit i a w m => f (g i) -> m (h i))
+  -> c h
 
 -- | Given a generic context @c@, runs the @'CircuitFun'@ from @f@ many @c g@'s into @c h@.
 fromCircuitVF xs m = fromCircuitF (pack xs) (m . unComp1)

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Class.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Class.hs
@@ -12,6 +12,7 @@ module ZkFold.Symbolic.Data.Class (
   Range,
   LayoutData (..),
   GSymbolicData (..),
+  withoutConstraints,
 ) where
 
 import Control.Applicative (liftA2)
@@ -33,7 +34,6 @@ import Data.Typeable (Proxy (..))
 import GHC.Generics (U1 (..), (:*:) (..), (:.:) (..))
 import qualified GHC.Generics as G
 import Text.Show (Show)
-
 import ZkFold.Algebra.Number (KnownNat)
 import ZkFold.Control.HApplicative (hliftA2, hpure)
 import ZkFold.Data.ByteString (Binary1)
@@ -43,7 +43,7 @@ import ZkFold.Data.Package (pack, unpack)
 import ZkFold.Data.Product (fstP, sndP)
 import ZkFold.Data.Vector (Vector)
 import qualified ZkFold.Symbolic.Algorithm.Interpolation as I
-import ZkFold.Symbolic.Class (BaseField, Symbolic, WitnessField)
+import ZkFold.Symbolic.Class (BaseField, Symbolic, WitnessField, embedW, witnessF)
 
 type PayloadFunctor f = (Representable f, Binary (R.Rep f))
 
@@ -121,6 +121,12 @@ class
     => (c (Layout x), Payload x (WitnessField c))
     -> x
   restore f = G.to (grestore f)
+
+withoutConstraints
+  :: SymbolicData x
+  => x
+  -> x
+withoutConstraints x = restore (embedW $ witnessF $ arithmetize x, payload x)
 
 instance (Symbolic c, LayoutFunctor f) => SymbolicData (c f) where
   type Context (c f) = c

--- a/symbolic-base/src/ZkFold/Symbolic/MonadCircuit.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/MonadCircuit.hs
@@ -13,15 +13,15 @@ import Data.Set (singleton)
 import Data.Traversable (Traversable)
 import Data.Typeable (Typeable)
 import GHC.Generics (Par1 (..))
-import Prelude (Integer)
-
 import ZkFold.Algebra.Class
 import ZkFold.Algebra.Field (Zp)
 import ZkFold.ArithmeticCircuit.Lookup
+import ZkFold.Data.Eq (Eq)
+import Prelude (Integer)
 
 -- | A 'ResidueField' is a 'FiniteField'
 -- backed by a 'Euclidean' integral type.
-class (FiniteField a, Euclidean (IntegralOf a)) => ResidueField a where
+class (FiniteField a, Euclidean (IntegralOf a), Eq (IntegralOf a)) => ResidueField a where
   type IntegralOf a :: Type
   fromIntegral :: IntegralOf a -> a
   toIntegral :: a -> IntegralOf a
@@ -106,7 +106,8 @@ class
   --   (see 'lookupConstraint').
   registerFunction
     :: (Representable f, Binary (Rep f), Typeable f, Traversable g, Typeable g)
-    => (forall x. ResidueField x => f x -> g x) -> m (FunctionId (f a -> g a))
+    => (forall x. ResidueField x => f x -> g x)
+    -> m (FunctionId (f a -> g a))
 
   -- | Adds new lookup constraint to the system.
   --   For examples of lookup constraints, see 'rangeConstraint'.

--- a/symbolic-base/src/ZkFold/Symbolic/MonadCircuit.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/MonadCircuit.hs
@@ -16,12 +16,21 @@ import GHC.Generics (Par1 (..))
 import ZkFold.Algebra.Class
 import ZkFold.Algebra.Field (Zp)
 import ZkFold.ArithmeticCircuit.Lookup
-import ZkFold.Data.Eq (Eq)
+import ZkFold.Control.Conditional (Conditional)
+import ZkFold.Data.Eq (BooleanOf, Eq)
 import Prelude (Integer)
 
 -- | A 'ResidueField' is a 'FiniteField'
 -- backed by a 'Euclidean' integral type.
-class (FiniteField a, Euclidean (IntegralOf a), Eq (IntegralOf a)) => ResidueField a where
+class
+  ( FiniteField a
+  , Euclidean (IntegralOf a)
+  , Eq (IntegralOf a)
+  , Conditional (BooleanOf (IntegralOf a)) (BooleanOf (IntegralOf a))
+  , Conditional (BooleanOf (IntegralOf a)) (IntegralOf a)
+  ) =>
+  ResidueField a
+  where
   type IntegralOf a :: Type
   fromIntegral :: IntegralOf a -> a
   toIntegral :: a -> IntegralOf a

--- a/symbolic-base/symbolic-base.cabal
+++ b/symbolic-base/symbolic-base.cabal
@@ -179,6 +179,7 @@ library
       ZkFold.Protocol.IVC.FiatShamir
       ZkFold.Protocol.IVC.Internal
       ZkFold.Protocol.IVC.NARK
+      ZkFold.Protocol.IVC.OperationRecord
       ZkFold.Protocol.IVC.Oracle
       ZkFold.Protocol.IVC.Predicate
       ZkFold.Protocol.IVC.RecursiveFunction

--- a/symbolic-base/symbolic-base.cabal
+++ b/symbolic-base/symbolic-base.cabal
@@ -177,6 +177,7 @@ library
       ZkFold.Protocol.IVC.CommitOpen
       ZkFold.Protocol.IVC.Commit
       ZkFold.Protocol.IVC.FiatShamir
+      ZkFold.Protocol.IVC.ForeignField
       ZkFold.Protocol.IVC.Internal
       ZkFold.Protocol.IVC.NARK
       ZkFold.Protocol.IVC.OperationRecord
@@ -185,6 +186,7 @@ library
       ZkFold.Protocol.IVC.RecursiveFunction
       ZkFold.Protocol.IVC.SpecialSound
       ZkFold.Protocol.IVC.VerifierCircuit
+      ZkFold.Protocol.IVC.WeierstrassWitness
       ZkFold.Protocol.KZG
       ZkFold.Protocol.Plonkup
       ZkFold.Protocol.Plonkup.LookupConstraint

--- a/symbolic-base/symbolic-base.cabal
+++ b/symbolic-base/symbolic-base.cabal
@@ -414,6 +414,7 @@ test-suite symbolic-base-test
       directory                        <= 1.3.8.5,
       filepath                         <= 1.5.2.0,
       hspec                                < 2.12,
+      lens                                       ,
       QuickCheck                                 ,
       quickcheck-instances                       ,
       regex-tdfa                       <= 1.3.2.2,

--- a/symbolic-base/test/Main.hs
+++ b/symbolic-base/test/Main.hs
@@ -29,7 +29,6 @@ import Tests.Symbolic.Data.List (specList)
 import Tests.Symbolic.Data.MerkleTree (specMerkleTree)
 import Tests.Symbolic.Data.Sum (specSum)
 import Tests.Symbolic.Data.UInt (specUInt)
-import ZkFold.Algebra.Class (zero)
 import Prelude hiding (
   Bool,
   Fractional (..),
@@ -43,45 +42,45 @@ import Prelude hiding (
 
 spec :: RandomGen g => g -> Spec
 spec gen = do
-  -- describe "symbolic-base-test (Algebra)" $ do
-  --   specGroup
-  --   specField
-  --   specEllipticCurve
-  --   specPairing
-  --   specPermutation
-  --   specUnivariate
-  --   specReedSolomon
-  --   specGroebner
+  describe "symbolic-base-test (Algebra)" $ do
+    specGroup
+    specField
+    specEllipticCurve
+    specPairing
+    specPermutation
+    specUnivariate
+    specReedSolomon
+    specGroebner
 
-  -- describe "symbolic-base-test (Serialization)" $ do
-  --   specBinary
+  describe "symbolic-base-test (Serialization)" $ do
+    specBinary
 
   describe "symbolic-base-test (Protocols)" $ do
-    -- specPlonkup
-    -- specNonInteractiveProof
+    specPlonkup
+    specNonInteractiveProof
     specIVC
 
--- describe "symbolic-base-test (Symbolic compiler)" $ do
---   specArithmeticCircuit
---   specCompiler
+  describe "symbolic-base-test (Symbolic compiler)" $ do
+    specArithmeticCircuit
+    specCompiler
 
--- describe "symbolic-base-test (Symbolic data)" $ do
---   specUInt
---   specInt
---   specFFA
---   specByteString
---   specHash
---   specList
---   specMerkleTree
---   specSum
+  describe "symbolic-base-test (Symbolic data)" $ do
+    specUInt
+    specInt
+    specFFA
+    specByteString
+    specHash
+    specList
+    specMerkleTree
+    specSum
 
--- describe "symbolic-base-test (Symbolic cryptography)" $ do
---   specBlake2b
---   specJWT
---   specRSA gen
---   specSHA2Natural
---   specSHA2
---   specKeccak
+  describe "symbolic-base-test (Symbolic cryptography)" $ do
+    specBlake2b
+    specJWT
+    specRSA gen
+    specSHA2Natural
+    specSHA2
+    specKeccak
 
 main :: IO ()
 main = hspec . spec =<< initStdGen

--- a/symbolic-base/test/Main.hs
+++ b/symbolic-base/test/Main.hs
@@ -2,17 +2,6 @@ module Main where
 
 import System.Random (RandomGen, initStdGen)
 import Test.Hspec (Spec, describe, hspec)
-import Prelude hiding (
-  Bool,
-  Fractional (..),
-  Num (..),
-  drop,
-  length,
-  replicate,
-  take,
-  (==),
- )
-
 import Tests.Algebra.EllipticCurve (specEllipticCurve)
 import Tests.Algebra.Field (specField)
 import Tests.Algebra.Groebner (specGroebner)
@@ -22,7 +11,7 @@ import Tests.Algebra.Permutation (specPermutation)
 import Tests.Algebra.ReedSolomon (specReedSolomon)
 import Tests.Algebra.Univariate (specUnivariate)
 import Tests.Data.Binary (specBinary)
-import Tests.Protocol.IVC (specIVC)
+import Tests.Protocol.IVC
 import Tests.Protocol.NonInteractiveProof (specNonInteractiveProof)
 import Tests.Protocol.Plonkup (specPlonkup)
 import Tests.Symbolic.Algorithm.Blake2b (specBlake2b)
@@ -40,48 +29,59 @@ import Tests.Symbolic.Data.List (specList)
 import Tests.Symbolic.Data.MerkleTree (specMerkleTree)
 import Tests.Symbolic.Data.Sum (specSum)
 import Tests.Symbolic.Data.UInt (specUInt)
+import ZkFold.Algebra.Class (zero)
+import Prelude hiding (
+  Bool,
+  Fractional (..),
+  Num (..),
+  drop,
+  length,
+  replicate,
+  take,
+  (==),
+ )
 
 spec :: RandomGen g => g -> Spec
 spec gen = do
-  describe "symbolic-base-test (Algebra)" $ do
-    specGroup
-    specField
-    specEllipticCurve
-    specPairing
-    specPermutation
-    specUnivariate
-    specReedSolomon
-    specGroebner
+  -- describe "symbolic-base-test (Algebra)" $ do
+  --   specGroup
+  --   specField
+  --   specEllipticCurve
+  --   specPairing
+  --   specPermutation
+  --   specUnivariate
+  --   specReedSolomon
+  --   specGroebner
 
-  describe "symbolic-base-test (Serialization)" $ do
-    specBinary
+  -- describe "symbolic-base-test (Serialization)" $ do
+  --   specBinary
 
   describe "symbolic-base-test (Protocols)" $ do
-    specPlonkup
-    specNonInteractiveProof
+    -- specPlonkup
+    -- specNonInteractiveProof
     specIVC
 
-  describe "symbolic-base-test (Symbolic compiler)" $ do
-    specArithmeticCircuit
-    specCompiler
+-- describe "symbolic-base-test (Symbolic compiler)" $ do
+--   specArithmeticCircuit
+--   specCompiler
 
-  describe "symbolic-base-test (Symbolic data)" $ do
-    specUInt
-    specInt
-    specFFA
-    specByteString
-    specHash
-    specList
-    specMerkleTree
-    specSum
+-- describe "symbolic-base-test (Symbolic data)" $ do
+--   specUInt
+--   specInt
+--   specFFA
+--   specByteString
+--   specHash
+--   specList
+--   specMerkleTree
+--   specSum
 
-  describe "symbolic-base-test (Symbolic cryptography)" $ do
-    specBlake2b
-    specJWT
-    specRSA gen
-    specSHA2Natural
-    specSHA2
-    specKeccak
+-- describe "symbolic-base-test (Symbolic cryptography)" $ do
+--   specBlake2b
+--   specJWT
+--   specRSA gen
+--   specSHA2Natural
+--   specSHA2
+--   specKeccak
 
 main :: IO ()
 main = hspec . spec =<< initStdGen

--- a/symbolic-base/test/Tests/Protocol/IVC.hs
+++ b/symbolic-base/test/Tests/Protocol/IVC.hs
@@ -27,6 +27,7 @@ import ZkFold.Protocol.IVC.AccumulatorScheme as Acc
 import ZkFold.Protocol.IVC.Commit (hcommit)
 import ZkFold.Protocol.IVC.CommitOpen (commitOpen)
 import ZkFold.Protocol.IVC.FiatShamir (FiatShamir, fiatShamir)
+import qualified ZkFold.Protocol.IVC.FiatShamir as FS
 import ZkFold.Protocol.IVC.NARK (
   NARKInstanceProof (..),
   NARKProof (..),
@@ -55,9 +56,11 @@ instance OracleSource A (DataSource C) where
 type A = Zp BLS12_381_Scalar
 
 -- type F = FieldElement (Interpreter A)
+
 type F = A
 
 -- type C = WeierstrassWitness (Interpreter A)
+
 type C = BLS12_381_G1_Point
 
 type I = Vector 1
@@ -151,7 +154,7 @@ specIVC = do
       it "must output zeros on the public input and message" $ do
         withMaxSuccess 10 $ property $ \p ->
           (\(a, b) -> all ((== zero) . dataSource) (toList a) && all (== zero) b) $
-            SPS.verifier (sps p) (pi p) (singleton $ zip (ms p) (cs p)) (unsafeToVector [])
+            FS.verifier (sps p) (pi p) (zip (ms p) (cs p)) (unsafeToVector [])
   describe "Accumulator scheme specification" $ do
     describe "decider" $ do
       it "must output zeros" $ do

--- a/symbolic-base/test/Tests/Protocol/IVC.hs
+++ b/symbolic-base/test/Tests/Protocol/IVC.hs
@@ -140,9 +140,8 @@ specIVC = do
 
   describe "WeierstrassWitness" $ do
     it "is a homomorphic commitment" $ do
-      withMaxSuccess 10 $ property $ \(fromConstant @Integer -> p) (fromConstant @Integer @Integer -> q) ->
-        hcommit @(WeierstrassWitness (Interpreter A)) [p] ZkFold.== zero
-  -- hcommit @(WeierstrassWitness (Interpreter A)) [p + q] ZkFold.== hcommit [p] + hcommit [q]
+      withMaxSuccess 10 $ property $ \(fromConstant @Integer -> p) (fromConstant @Integer -> q) ->
+        hcommit @(WeierstrassWitness (Interpreter A)) [p + q] ZkFold.== hcommit [p] + hcommit [q]
   describe "Special sound protocol specification" $ do
     describe "verifier" $ do
       it "must output zeros on the public input and message" $ do

--- a/symbolic-base/test/Tests/Protocol/IVC.hs
+++ b/symbolic-base/test/Tests/Protocol/IVC.hs
@@ -1,25 +1,28 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Tests.Protocol.IVC where
 
 import Control.Lens ((^.))
 import Data.Bifunctor (bimap, first)
+import Data.Foldable (toList)
 import GHC.Generics (U1 (..))
 import Test.Hspec (Spec, describe, it)
 import Test.QuickCheck (property, withMaxSuccess)
 import ZkFold.Algebra.Class (FromConstant (..), ToConstant (..), one, zero)
-import ZkFold.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Scalar)
+import ZkFold.Algebra.EllipticCurve.BLS12_381 (BLS12_381_G1_Point, BLS12_381_Scalar)
+import ZkFold.Algebra.EllipticCurve.Class (Point (..), Weierstrass (..))
 import ZkFold.Algebra.Field (Zp)
-import ZkFold.Algebra.Number (Natural)
+import ZkFold.Algebra.Number (Natural, value)
 import ZkFold.Algebra.Polynomial.Univariate (evalPolyVec)
 import ZkFold.Algebra.Polynomial.Univariate.Simple (fromVector)
 import ZkFold.Data.Package (packed, unpacked)
-import ZkFold.Data.Vector (Vector (..), item, singleton, unsafeToVector)
+import ZkFold.Data.Vector (Vector (..), item, singleton, unsafeToVector, zip)
 import ZkFold.Protocol.IVC.Accumulator (
   Accumulator (..),
   emptyAccumulator,
   x,
  )
 import ZkFold.Protocol.IVC.AccumulatorScheme as Acc
-import ZkFold.Protocol.IVC.AlgebraicMap (algebraicMap)
 import ZkFold.Protocol.IVC.CommitOpen (commitOpen)
 import ZkFold.Protocol.IVC.FiatShamir (FiatShamir, fiatShamir)
 import ZkFold.Protocol.IVC.NARK (
@@ -27,21 +30,32 @@ import ZkFold.Protocol.IVC.NARK (
   NARKProof (..),
   narkInstanceProof,
  )
-import ZkFold.Protocol.IVC.Oracle (mimcHash)
+import ZkFold.Protocol.IVC.Oracle (OracleSource (..), mimcHash)
 import ZkFold.Protocol.IVC.Predicate (Predicate (..), predicate)
 import ZkFold.Protocol.IVC.RecursiveFunction (DataSource (..))
-import ZkFold.Protocol.IVC.SpecialSound (specialSoundProtocol)
+import ZkFold.Protocol.IVC.SpecialSound (SpecialSoundProtocol, specialSoundProtocol)
+import qualified ZkFold.Protocol.IVC.SpecialSound as SPS
 import ZkFold.Symbolic.Class (BaseField, Symbolic)
-import ZkFold.Symbolic.Data.EllipticCurve.BLS12_381 (BLS12_381_G1_Point)
 import ZkFold.Symbolic.Data.FieldElement (FieldElement (..))
-import ZkFold.Symbolic.Interpreter (Interpreter)
-import Prelude hiding (Num (..), pi, replicate, sum, (+), (^))
+import Prelude hiding (Num (..), pi, replicate, sum, zip, (+), (^))
+
+instance OracleSource A (DataSource C) where
+  source (DataSource (Weierstrass (Point a b isInf))) =
+    let a1 = fromConstant $ toConstant a `mod` (value @BLS12_381_Scalar)
+        a2 = fromConstant $ toConstant a `div` (value @BLS12_381_Scalar)
+        b1 = fromConstant $ toConstant b `mod` (value @BLS12_381_Scalar)
+        b2 = fromConstant $ toConstant b `div` (value @BLS12_381_Scalar)
+        isInf1 = if isInf then one else zero
+     in [a1, a2, b1, b2, isInf1]
 
 type A = Zp BLS12_381_Scalar
 
-type F = FieldElement (Interpreter A)
+-- type F = FieldElement (Interpreter A)
 
-type C = BLS12_381_G1_Point (Interpreter A)
+type F = A
+
+-- type C = BLS12_381_G1_Point (Interpreter A)
+type C = BLS12_381_G1_Point
 
 type I = Vector 1
 
@@ -50,6 +64,8 @@ type P = U1
 type K = 1
 
 type PHI = Predicate A I P
+
+type SPS0 = SpecialSoundProtocol 1 I P [F] [A] A
 
 type SPS = FiatShamir 1 I P (DataSource C) [F] [A] F
 
@@ -74,6 +90,13 @@ testFunction p i _ =
       y = singleton $ evalPolyVec p' $ item z
    in packed $ fromFieldElement <$> y
 
+-- testFunction :: PAR -> I F -> P F -> I F
+-- testFunction p i _ =
+--   let p' = fromVector $ fmap fromConstant p
+--       z = fromConstant <$> unpacked i
+--       y = singleton $ evalPolyVec p' $ item z
+--    in packed $ fromConstant <$> y
+
 -- testPredicateCircuit :: PAR -> AC
 -- testPredicateCircuit p = predicateCircuit @A @I @P $ testPredicate p
 
@@ -82,22 +105,28 @@ specIVC = do
   let phi :: PAR -> PHI
       phi = predicate . testFunction
 
-      sps :: PAR -> SPS
-      sps = fiatShamir mimcHash . commitOpen fromConstant toConstant . specialSoundProtocol @D fromConstant toConstant . phi
+      sps0 :: PAR -> SPS0
+      sps0 = specialSoundProtocol @D fromConstant id . phi
 
-      acc0 :: PAR -> Accumulator K I (DataSource C) F
-      acc0 = emptyAccumulator @D . phi
+      sps :: PAR -> SPS
+      sps = fiatShamir mimcHash . commitOpen fromConstant id . sps0
 
       pi0 :: I F
       pi0 = singleton $ fromConstant @ZkFold.Algebra.Number.Natural 42
 
+      pi' p = SPS.input (sps0 p) pi0 U1
+      ms' p = SPS.prover (sps0 p) pi0 U1 zero 1
+
       narkIP p = narkInstanceProof (sps p) pi0 U1
-      pi p = let NARKInstanceProof pi' _ = narkIP p in pi'
-      cs p = let NARKInstanceProof _ (NARKProof cs' _) = narkIP p in cs'
-      ms p = let NARKInstanceProof _ (NARKProof _ ms') = narkIP p in ms'
+      pi p = let NARKInstanceProof z _ = narkIP p in z
+      cs p = let NARKInstanceProof _ (NARKProof z _) = narkIP p in z
+      ms p = let NARKInstanceProof _ (NARKProof _ z) = narkIP p in z
 
       scheme :: PAR -> AccumulatorScheme D 1 I (DataSource C) F
       scheme = accumulatorScheme mimcHash . phi
+
+      acc0 :: PAR -> Accumulator K I (DataSource C) F
+      acc0 = emptyAccumulator @D . phi
 
       acc p = fst $ prover (scheme p) (acc0 p) $ NARKInstanceProof (pi p) (NARKProof (cs p) (ms p))
       pf p = snd $ prover (scheme p) (acc0 p) $ NARKInstanceProof (pi p) (NARKProof (cs p) (ms p))
@@ -105,16 +134,22 @@ specIVC = do
       verifierResult p = first dataSource $ verifier (scheme p) (pi p) (cs p) (acc0 p ^. x) (pf p)
       deciderResult p = bimap (fmap dataSource) dataSource $ decider (scheme p) $ acc p
 
-  describe "Algebraic map specification" $ do
-    describe "Algebraic map" $ do
+  describe "Special sound protocol specification" $ do
+    describe "verifier" $ do
       it "must output zeros on the public input and message" $ do
         withMaxSuccess 10 $ property $ \p ->
-          any (/= zero) $ algebraicMap @D (phi p) (pi p) (ms p) (unsafeToVector []) one
+          all (== zero) $ SPS.verifier (sps0 p) (pi' p) (singleton $ ms' p) (unsafeToVector [])
+  describe "Fiat-Shamir Commit-Open protocol specificaation" $ do
+    describe "verifier" $ do
+      it "must output zeros on the public input and message" $ do
+        withMaxSuccess 10 $ property $ \p ->
+          (\(a, b) -> all ((== zero) . dataSource) (toList a) && all (== zero) b) $
+            SPS.verifier (sps p) (pi p) (singleton $ zip (ms p) (cs p)) (unsafeToVector [])
   describe "Accumulator scheme specification" $ do
     describe "decider" $ do
       it "must output zeros" $ do
         withMaxSuccess 10 $ property $ \p ->
-          deciderResult p == (singleton zero, zero)
+          deciderResult p == (zero, zero)
     describe "verifier" $ do
       it "must output zeros" $ do
         withMaxSuccess 10 $ property $ \p ->

--- a/symbolic-base/test/Tests/Protocol/IVC.hs
+++ b/symbolic-base/test/Tests/Protocol/IVC.hs
@@ -71,9 +71,9 @@ type K = 1
 
 type PHI = Predicate A I P
 
-type SPS0 = SpecialSoundProtocol 1 I P [F] [A] A
+type SPS0 = SpecialSoundProtocol 1 I P F
 
-type SPS = FiatShamir 1 I P (DataSource C) [F] [A] F
+type SPS = FiatShamir 1 I P (DataSource C) F
 
 type D = 2
 

--- a/symbolic-base/test/Tests/Protocol/IVC.hs
+++ b/symbolic-base/test/Tests/Protocol/IVC.hs
@@ -55,10 +55,9 @@ instance OracleSource A (DataSource C) where
 type A = Zp BLS12_381_Scalar
 
 -- type F = FieldElement (Interpreter A)
-
 type F = A
 
--- type C = BLS12_381_G1_Point (Interpreter A)
+-- type C = WeierstrassWitness (Interpreter A)
 type C = BLS12_381_G1_Point
 
 type I = Vector 1
@@ -110,10 +109,10 @@ specIVC = do
       phi = predicate . testFunction
 
       sps0 :: PAR -> SPS0
-      sps0 = specialSoundProtocol @D fromConstant id . phi
+      sps0 = specialSoundProtocol @D . phi
 
       sps :: PAR -> SPS
-      sps = fiatShamir mimcHash . commitOpen fromConstant id . sps0
+      sps = fiatShamir mimcHash . commitOpen . sps0
 
       pi0 :: I F
       pi0 = singleton $ fromConstant @ZkFold.Algebra.Number.Natural 42


### PR DESCRIPTION
- [x] Turns on accumulation scheme test.
- [x] Adds `WeierstrassWitness` type for EC curve point witnesses.
- [x] Adds `OperationRecord` type to use as commitments.

What's left for future PRs:

- Optimize performance (optional, but highly desirable)
- Enable recursive predicate / IVC tests
- Replace `WeierstrassWitness` with `OperationRecord` in tests
- Handle circuit fold when building a PlonkUp relation