### PR TITLE
Fix endianness bug

### DIFF
--- a/symbolic-base/src/ZkFold/Symbolic/Data/ByteString.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/ByteString.hs
@@ -412,10 +412,10 @@ bitwiseOperation (ByteString bits1) (ByteString bits2) cons =
       That j -> pure j
 
 instance (Symbolic c, NumberOfBits (BaseField c) ~ n) => Iso (FieldElement c) (ByteString n c) where
-  from = ByteString . binaryExpansion
+  from = ByteString . hmap V.reverse . binaryExpansion
 
 instance (Symbolic c, NumberOfBits (BaseField c) ~ n) => Iso (ByteString n c) (FieldElement c) where
-  from (ByteString a) = fromBinary a
+  from (ByteString a) = fromBinary (hmap V.reverse a)
 
 instance
   (Symbolic c, KnownNat n)


### PR DESCRIPTION
Resolves #597 by changing endianness of `ByteString`<->`FieldElement` conversion.
In the future, we'll add API for proper handling of endianness in `ByteString` module, maybe on top of `LittleEndian`/`BigEndian` newtypes we already have.