### PR TITLE
Integrating `OperationRecord` into IVC

### DIFF
--- a/symbolic-base/src/ZkFold/Algebra/Class.hs
+++ b/symbolic-base/src/ZkFold/Algebra/Class.hs
@@ -248,16 +248,21 @@ class FromConstant a a => AdditiveSemigroup a where
   double :: a -> a
   double a = a + a
 
+-- | A class of types with a neutral element with respect to addition.
+-- Split into a separate class since defining addition might need additional
+-- (undesirable) constraints.
+class Zero a where
+  -- | An identity with respect to addition:
+  --
+  -- [Identity] @x + zero == x@
+  zero :: a
+
 -- | A class of types with a binary associative, commutative operation and with
 -- an identity element.
 --
 -- While scaling by a natural is specified as a constraint, a default
 -- implementation is provided as a @'natScale'@ function.
-class (AdditiveSemigroup a, Scale Natural a) => AdditiveMonoid a where
-  -- | An identity with respect to addition:
-  --
-  -- [Identity] @x + zero == x@
-  zero :: a
+class (AdditiveSemigroup a, Scale Natural a, Zero a) => AdditiveMonoid a
 
 natScale :: AdditiveMonoid a => Natural -> a -> a
 
@@ -505,8 +510,10 @@ instance MultiplicativeMonoid Natural where
 instance AdditiveSemigroup Natural where
   (+) = (Haskell.+)
 
-instance AdditiveMonoid Natural where
+instance Zero Natural where
   zero = 0
+
+instance AdditiveMonoid Natural
 
 instance Semiring Natural
 
@@ -537,8 +544,10 @@ instance AdditiveSemigroup Integer where
 
 instance Scale Natural Integer
 
-instance AdditiveMonoid Integer where
+instance Zero Integer where
   zero = 0
+
+instance AdditiveMonoid Integer
 
 instance AdditiveGroup Integer where
   negate = Haskell.negate
@@ -580,8 +589,10 @@ instance AdditiveSemigroup Rational where
 
 instance Scale Natural Rational
 
-instance AdditiveMonoid Rational where
+instance Zero Rational where
   zero = 0
+
+instance AdditiveMonoid Rational
 
 instance Scale Integer Rational
 
@@ -632,8 +643,10 @@ instance AdditiveSemigroup Bool where
 
 instance Scale Natural Bool
 
-instance AdditiveMonoid Bool where
+instance Zero Bool where
   zero = False
+
+instance AdditiveMonoid Bool
 
 instance Scale Integer Bool
 
@@ -687,8 +700,10 @@ instance AdditiveSemigroup a => AdditiveSemigroup [a] where
 instance Scale b a => Scale b [a] where
   scale = map . scale
 
-instance AdditiveMonoid a => AdditiveMonoid [a] where
+instance Zero a => Zero [a] where
   zero = repeat zero
+
+instance AdditiveMonoid a => AdditiveMonoid [a]
 
 instance AdditiveGroup a => AdditiveGroup [a] where
   negate = map negate
@@ -724,8 +739,10 @@ instance AdditiveSemigroup a => AdditiveSemigroup (p -> a) where
 instance Scale b a => Scale b (p -> a) where
   scale = (.) . scale
 
-instance AdditiveMonoid a => AdditiveMonoid (p -> a) where
+instance Zero a => Zero (p -> a) where
   zero = const zero
+
+instance AdditiveMonoid a => AdditiveMonoid (p -> a)
 
 instance AdditiveGroup a => AdditiveGroup (p -> a) where
   negate = fmap negate
@@ -764,8 +781,10 @@ instance (MultiplicativeGroup a, Scale (Constant a f) (Constant a f)) => Multipl
 instance AdditiveSemigroup a => AdditiveSemigroup (Constant a f) where
   Constant x + Constant y = Constant (x + y)
 
-instance AdditiveMonoid a => AdditiveMonoid (Constant a f) where
+instance Zero a => Zero (Constant a f) where
   zero = Constant zero
+
+instance AdditiveMonoid a => AdditiveMonoid (Constant a f)
 
 instance AdditiveGroup a => AdditiveGroup (Constant a f) where
   Constant x - Constant y = Constant (x - y)
@@ -810,9 +829,10 @@ instance Scale Natural a => Scale Natural (Maybe a) where
 instance Scale Integer a => Scale Integer (Maybe a) where
   scale = fmap . scale
 
-instance AdditiveMonoid a => AdditiveMonoid (Maybe a) where
-  zero :: Maybe a
+instance Zero a => Zero (Maybe a) where
   zero = Just zero
+
+instance AdditiveMonoid a => AdditiveMonoid (Maybe a) where
 
 instance Exponent a Natural => Exponent (Maybe a) Natural where
   (^) :: Maybe a -> Natural -> Maybe a

--- a/symbolic-base/src/ZkFold/Algebra/Class.hs
+++ b/symbolic-base/src/ZkFold/Algebra/Class.hs
@@ -832,7 +832,7 @@ instance Scale Integer a => Scale Integer (Maybe a) where
 instance Zero a => Zero (Maybe a) where
   zero = Just zero
 
-instance AdditiveMonoid a => AdditiveMonoid (Maybe a) where
+instance AdditiveMonoid a => AdditiveMonoid (Maybe a)
 
 instance Exponent a Natural => Exponent (Maybe a) Natural where
   (^) :: Maybe a -> Natural -> Maybe a

--- a/symbolic-base/src/ZkFold/Algebra/EllipticCurve/Class.hs
+++ b/symbolic-base/src/ZkFold/Algebra/EllipticCurve/Class.hs
@@ -357,13 +357,17 @@ instance
             !z3 = square (y1 + z1) - yy - zz
          in Weierstrass (JacobianPoint x3 y3 z3)
 
+instance (Semiring field, Eq field) => Zero (Weierstrass curve (Point field)) where
+  zero = pointInf
+
 instance
   ( WeierstrassCurve curve field
   , Conditional (BooleanOf field) (BooleanOf field)
   , Conditional (BooleanOf field) (Weierstrass curve (Point field))
   )
   => AdditiveMonoid (Weierstrass curve (Point field))
-  where
+
+instance (Semiring field, Eq field) => Zero (Weierstrass curve (JacobianPoint field)) where
   zero = pointInf
 
 instance
@@ -372,8 +376,6 @@ instance
   , Conditional (BooleanOf field) (Weierstrass curve (JacobianPoint field))
   )
   => AdditiveMonoid (Weierstrass curve (JacobianPoint field))
-  where
-  zero = pointInf
 
 instance
   ( WeierstrassCurve curve field
@@ -491,11 +493,12 @@ instance
         y2 = (y0 * y1 - a * x0 * x1) // (one - d * x0 * x1 * y0 * y1)
      in pointXY x2 y2
 
+instance Semiring field => Zero (TwistedEdwards curve (AffinePoint field)) where
+  zero = pointXY zero one
+
 instance
   TwistedEdwardsCurve curve field
   => AdditiveMonoid (TwistedEdwards curve (AffinePoint field))
-  where
-  zero = pointXY zero one
 
 instance
   TwistedEdwardsCurve curve field

--- a/symbolic-base/src/ZkFold/Algebra/Field.hs
+++ b/symbolic-base/src/ZkFold/Algebra/Field.hs
@@ -94,8 +94,10 @@ instance KnownNat p => AdditiveSemigroup (Zp p) where
 instance KnownNat p => Scale Natural (Zp p) where
   scale c (Zp a) = toZp (scale c a)
 
-instance KnownNat p => AdditiveMonoid (Zp p) where
+instance Zero (Zp p) where
   zero = Zp 0
+
+instance KnownNat p => AdditiveMonoid (Zp p)
 
 instance KnownNat p => Scale Integer (Zp p) where
   scale c (Zp a) = toZp (scale c a)
@@ -253,8 +255,10 @@ instance Field f => AdditiveSemigroup (Ext2 f e) where
 instance Scale c f => Scale c (Ext2 f e) where
   scale c (Ext2 a b) = Ext2 (scale c a) (scale c b)
 
-instance Field f => AdditiveMonoid (Ext2 f e) where
+instance Zero f => Zero (Ext2 f e) where
   zero = Ext2 zero zero
+
+instance Field f => AdditiveMonoid (Ext2 f e)
 
 instance Field f => AdditiveGroup (Ext2 f e) where
   negate (Ext2 a b) = Ext2 (negate a) (negate b)
@@ -327,8 +331,10 @@ instance Field f => AdditiveSemigroup (Ext3 f e) where
 instance Scale c f => Scale c (Ext3 f e) where
   scale c (Ext3 d e f) = Ext3 (scale c d) (scale c e) (scale c f)
 
-instance Field f => AdditiveMonoid (Ext3 f e) where
+instance Zero f => Zero (Ext3 f e) where
   zero = Ext3 zero zero zero
+
+instance Field f => AdditiveMonoid (Ext3 f e)
 
 instance Field f => AdditiveGroup (Ext3 f e) where
   negate (Ext3 a b c) = Ext3 (negate a) (negate b) (negate c)

--- a/symbolic-base/src/ZkFold/Algebra/Polynomial/Multivariate/Internal.hs
+++ b/symbolic-base/src/ZkFold/Algebra/Polynomial/Multivariate/Internal.hs
@@ -116,8 +116,10 @@ instance (Eq coef, AdditiveMonoid coef, Ord var, Ord pow) => AdditiveSemigroup (
 instance Scale coef' coef => Scale coef' (Poly coef var pow) where
   scale coef' (UnsafePoly p) = UnsafePoly $ map (first (scale coef')) p
 
-instance (Eq coef, AdditiveMonoid coef, Ord var, Ord pow) => AdditiveMonoid (Poly coef var pow) where
+instance Zero (Poly coef var pow) where
   zero = UnsafePoly []
+
+instance (Eq coef, AdditiveMonoid coef, Ord var, Ord pow) => AdditiveMonoid (Poly coef var pow)
 
 instance (Eq coef, AdditiveGroup coef, Ord var, Ord pow) => AdditiveGroup (Poly coef var pow) where
   negate (UnsafePoly p) = UnsafePoly $ map (first negate) p

--- a/symbolic-base/src/ZkFold/Algebra/Polynomial/Univariate.hs
+++ b/symbolic-base/src/ZkFold/Algebra/Polynomial/Univariate.hs
@@ -173,8 +173,10 @@ instance {-# OVERLAPPING #-} (Field c, Eq c) => Scale (Poly c) (Poly c)
 instance Scale k c => Scale k (Poly c) where
   scale = fmap . scale
 
-instance (Ring c, Eq c) => AdditiveMonoid (Poly c) where
+instance Zero (Poly c) where
   zero = P V.empty
+
+instance (Ring c, Eq c) => AdditiveMonoid (Poly c)
 
 instance (Ring c, Eq c) => AdditiveGroup (Poly c) where
   negate (P cs) = P $ fmap negate cs
@@ -591,8 +593,10 @@ instance FromConstant Integer c => FromConstant Integer (PolyVec c size) where
 instance (Ring c, Eq c, KnownNat size) => AdditiveSemigroup (PolyVec c size) where
   PV l + PV r = toPolyVec $ zipVectorsWithDefault zero (+) l r
 
-instance (Ring c, Eq c, KnownNat size) => AdditiveMonoid (PolyVec c size) where
+instance Zero (PolyVec c size) where
   zero = PV V.empty
+
+instance (Ring c, Eq c, KnownNat size) => AdditiveMonoid (PolyVec c size)
 
 instance (Ring c, Eq c, KnownNat size) => AdditiveGroup (PolyVec c size) where
   negate (PV cs) = PV $ fmap negate cs

--- a/symbolic-base/src/ZkFold/Algebra/Polynomial/Univariate/Simple.hs
+++ b/symbolic-base/src/ZkFold/Algebra/Polynomial/Univariate/Simple.hs
@@ -77,8 +77,10 @@ instance (Semiring a, KnownNat n) => Exponent (SimplePoly a n) Natural where
 instance AdditiveSemigroup a => AdditiveSemigroup (SimplePoly a n) where
   SimplePoly p + SimplePoly q = SimplePoly $ alignWith (T.mergeThese (+)) p q
 
-instance AdditiveMonoid a => AdditiveMonoid (SimplePoly a n) where
+instance Zero (SimplePoly a n) where
   zero = SimplePoly V.empty
+
+instance AdditiveMonoid a => AdditiveMonoid (SimplePoly a n)
 
 instance AdditiveGroup a => AdditiveGroup (SimplePoly a n) where
   negate = SimplePoly . fmap negate . coeffs

--- a/symbolic-base/src/ZkFold/ArithmeticCircuit/Children.hs
+++ b/symbolic-base/src/ZkFold/ArithmeticCircuit/Children.hs
@@ -6,7 +6,7 @@ import Data.Function (const, flip, id, (.))
 import Data.Monoid (Monoid, mempty)
 import Data.Ord (Ord)
 import Data.Semigroup (Semigroup, (<>))
-import Data.Set (Set, singleton)
+import Data.Set (Set, empty, singleton)
 
 import ZkFold.Algebra.Class
 import ZkFold.ArithmeticCircuit.Witness (WitnessF (..))
@@ -56,8 +56,10 @@ instance Finite a => Finite (Children a v) where
 instance Ord v => AdditiveSemigroup (Children a v) where
   (+) = (<>)
 
+instance Zero (Children a v) where
+  zero = C empty
+
 instance Ord v => AdditiveMonoid (Children a v) where
-  zero = mempty
 
 instance Ord v => AdditiveGroup (Children a v) where
   negate = id

--- a/symbolic-base/src/ZkFold/ArithmeticCircuit/Children.hs
+++ b/symbolic-base/src/ZkFold/ArithmeticCircuit/Children.hs
@@ -59,7 +59,7 @@ instance Ord v => AdditiveSemigroup (Children a v) where
 instance Zero (Children a v) where
   zero = C empty
 
-instance Ord v => AdditiveMonoid (Children a v) where
+instance Ord v => AdditiveMonoid (Children a v)
 
 instance Ord v => AdditiveGroup (Children a v) where
   negate = id

--- a/symbolic-base/src/ZkFold/ArithmeticCircuit/MerkleHash.hs
+++ b/symbolic-base/src/ZkFold/ArithmeticCircuit/MerkleHash.hs
@@ -68,8 +68,10 @@ instance MultiplicativeMonoid (MerkleHash n) where
 instance AdditiveSemigroup (MerkleHash n) where
   M x + M y = merkleHash (Add, x, y)
 
-instance AdditiveMonoid (MerkleHash n) where
+instance Zero (MerkleHash n) where
   zero = fromConstant (zero :: Natural)
+
+instance AdditiveMonoid (MerkleHash n)
 
 instance Semiring (MerkleHash n)
 

--- a/symbolic-base/src/ZkFold/ArithmeticCircuit/Witness.hs
+++ b/symbolic-base/src/ZkFold/ArithmeticCircuit/Witness.hs
@@ -54,7 +54,9 @@ instance Exponent (WitnessF a v) Integer where WitnessF f ^ p = WitnessF (f ^ p)
 
 instance AdditiveSemigroup (WitnessF a v) where WitnessF f + WitnessF g = WitnessF (f + g)
 
-instance AdditiveMonoid (WitnessF a v) where zero = WitnessF zero
+instance Zero (WitnessF a v) where zero = WitnessF zero
+
+instance AdditiveMonoid (WitnessF a v)
 
 instance AdditiveGroup (WitnessF a v) where
   negate (WitnessF f) = WitnessF (negate f)
@@ -128,7 +130,9 @@ instance Exponent (EuclideanF a v) Natural where EuclideanF f ^ p = EuclideanF (
 
 instance AdditiveSemigroup (EuclideanF a v) where EuclideanF f + EuclideanF g = EuclideanF (f + g)
 
-instance AdditiveMonoid (EuclideanF a v) where zero = EuclideanF zero
+instance Zero (EuclideanF a v) where zero = EuclideanF zero
+
+instance AdditiveMonoid (EuclideanF a v)
 
 instance AdditiveGroup (EuclideanF a v) where
   negate (EuclideanF f) = EuclideanF (negate f)

--- a/symbolic-base/src/ZkFold/ArithmeticCircuit/WitnessEstimation.hs
+++ b/symbolic-base/src/ZkFold/ArithmeticCircuit/WitnessEstimation.hs
@@ -56,8 +56,10 @@ c1 .+ ConstUVar c2 = ConstUVar (c1 + c2)
 c .+ LinUVar k x b = LinUVar k x (b + c)
 _ .+ More = More
 
-instance (AdditiveMonoid a, Eq a) => AdditiveMonoid (UVar a) where
+instance Zero a => Zero (UVar a) where
   zero = ConstUVar zero
+
+instance (AdditiveMonoid a, Eq a) => AdditiveMonoid (UVar a)
 
 instance (AdditiveGroup a, Eq a) => AdditiveGroup (UVar a) where
   negate = fmap negate

--- a/symbolic-base/src/ZkFold/Data/Sparse/Vector.hs
+++ b/symbolic-base/src/ZkFold/Data/Sparse/Vector.hs
@@ -57,8 +57,10 @@ instance (KnownNat size, AdditiveMonoid a, Eq a) => AdditiveSemigroup (SVector s
 instance Scale c a => Scale c (SVector size a) where
   scale c (SVector as) = SVector (map (scale c) as)
 
-instance (KnownNat size, AdditiveMonoid a, Eq a) => AdditiveMonoid (SVector size a) where
+instance Zero (SVector size a) where
   zero = SVector empty
+
+instance (KnownNat size, AdditiveMonoid a, Eq a) => AdditiveMonoid (SVector size a)
 
 instance (KnownNat size, AdditiveGroup a, Eq a) => AdditiveGroup (SVector size a) where
   negate = fmap negate

--- a/symbolic-base/src/ZkFold/Data/Vector.hs
+++ b/symbolic-base/src/ZkFold/Data/Vector.hs
@@ -251,8 +251,10 @@ instance AdditiveSemigroup a => AdditiveSemigroup (Vector n a) where
 instance Scale b a => Scale b (Vector n a) where
   scale = fmap . scale
 
-instance (AdditiveMonoid a, KnownNat n) => AdditiveMonoid (Vector n a) where
+instance (Zero a, KnownNat n) => Zero (Vector n a) where
   zero = tabulate (const zero)
+
+instance (AdditiveMonoid a, KnownNat n) => AdditiveMonoid (Vector n a)
 
 instance (AdditiveGroup a, KnownNat n) => AdditiveGroup (Vector n a) where
   negate = fmap negate

--- a/symbolic-base/src/ZkFold/FFI/Rust/RustBLS.hs
+++ b/symbolic-base/src/ZkFold/FFI/Rust/RustBLS.hs
@@ -56,7 +56,7 @@ instance Binary Fr where
   get = h2r <$> get
 
 instance Eq Fr where
-  (==) a b = (r2h a) == (r2h b)
+  (==) a b = r2h a == r2h b
 
 instance ZkFold.Data.Eq.Eq Fr where
   type BooleanOf Fr = Bool
@@ -81,8 +81,10 @@ instance Exponent Fr Integer where
 instance AdditiveSemigroup Fr where
   (+) = runRustFun2 r_scalar_add
 
-instance AdditiveMonoid Fr where
+instance Zero Fr where
   zero = runRustFun0 r_scalar_zero
+
+instance AdditiveMonoid Fr
 
 instance AdditiveGroup Fr where
   (-) = runRustFun2 r_scalar_sub
@@ -173,10 +175,13 @@ deriving newtype instance AdditiveSemigroup Rust_BLS12_381_G1_JacobianPoint
 instance AdditiveSemigroup Rust_BLS12_381_G1_Point where
   (+) = runRustFun2 r_g1_add
 
+deriving newtype instance Zero Rust_BLS12_381_G1_JacobianPoint
 deriving newtype instance AdditiveMonoid Rust_BLS12_381_G1_JacobianPoint
 
-instance AdditiveMonoid Rust_BLS12_381_G1_Point where
+instance Zero Rust_BLS12_381_G1_Point where
   zero = runRustFun0 r_g1_zero
+
+instance AdditiveMonoid Rust_BLS12_381_G1_Point
 
 deriving newtype instance AdditiveGroup Rust_BLS12_381_G1_JacobianPoint
 
@@ -226,10 +231,13 @@ deriving newtype instance AdditiveSemigroup Rust_BLS12_381_G2_JacobianPoint
 instance AdditiveSemigroup Rust_BLS12_381_G2_Point where
   (+) = runRustFun2 r_g2_add
 
+deriving newtype instance Zero Rust_BLS12_381_G2_JacobianPoint
 deriving newtype instance AdditiveMonoid Rust_BLS12_381_G2_JacobianPoint
 
-instance AdditiveMonoid Rust_BLS12_381_G2_Point where
+instance Zero Rust_BLS12_381_G2_Point where
   zero = runRustFun0 r_g2_zero
+
+instance AdditiveMonoid Rust_BLS12_381_G2_Point
 
 deriving newtype instance AdditiveGroup Rust_BLS12_381_G2_JacobianPoint
 
@@ -275,15 +283,6 @@ instance UnivariateRingPolyVec Fr (RustPolyVec Fr) where
 
   (+.) :: forall size. Fr -> RustPolyVec Fr size -> RustPolyVec Fr size
   (+.) = runRustFun2 r_poly_add_scalar
-
-  toPolyVec :: forall size. KnownNat size => V.Vector Fr -> RustPolyVec Fr size
-  toPolyVec a = h2r $ toPolyVec (r2h <$> a)
-
-  fromPolyVec :: forall size. KnownNat size => RustPolyVec Fr size -> V.Vector Fr
-  fromPolyVec a = h2r <$> fromPolyVec (r2h a)
-
-  evalPolyVec :: forall size. KnownNat size => RustPolyVec Fr size -> Fr -> Fr
-  evalPolyVec pv x = h2r $ evalPolyVec (r2h pv) (r2h x)
 
 instance UnivariateFieldPolyVec Fr (RustPolyVec Fr) where
   (./.) :: RustPolyVec Fr size -> RustPolyVec Fr size -> RustPolyVec Fr size
@@ -333,8 +332,10 @@ instance KnownNat size => FromConstant Integer (RustPolyVec Fr size) where
 instance KnownNat size => AdditiveSemigroup (RustPolyVec Fr size) where
   (+) = runRustFun2 r_poly_add
 
-instance KnownNat size => AdditiveMonoid (RustPolyVec Fr size) where
+instance KnownNat size => Zero (RustPolyVec Fr size) where
   zero = runRustFun0 r_poly_zero
+
+instance KnownNat size => AdditiveMonoid (RustPolyVec Fr size)
 
 instance KnownNat size => AdditiveGroup (RustPolyVec Fr size) where
   (-) = runRustFun2 r_poly_sub

--- a/symbolic-base/src/ZkFold/FFI/Rust/RustBLS.hs
+++ b/symbolic-base/src/ZkFold/FFI/Rust/RustBLS.hs
@@ -341,7 +341,7 @@ instance KnownNat size => FromConstant Integer (RustPolyVec Fr size) where
 instance KnownNat size => AdditiveSemigroup (RustPolyVec Fr size) where
   (+) = runRustFun2 r_poly_add
 
-instance KnownNat size => Zero (RustPolyVec Fr size) where
+instance Zero (RustPolyVec Fr size) where
   zero = runRustFun0 r_poly_zero
 
 instance KnownNat size => AdditiveMonoid (RustPolyVec Fr size)

--- a/symbolic-base/src/ZkFold/FFI/Rust/RustBLS.hs
+++ b/symbolic-base/src/ZkFold/FFI/Rust/RustBLS.hs
@@ -176,6 +176,7 @@ instance AdditiveSemigroup Rust_BLS12_381_G1_Point where
   (+) = runRustFun2 r_g1_add
 
 deriving newtype instance Zero Rust_BLS12_381_G1_JacobianPoint
+
 deriving newtype instance AdditiveMonoid Rust_BLS12_381_G1_JacobianPoint
 
 instance Zero Rust_BLS12_381_G1_Point where
@@ -232,6 +233,7 @@ instance AdditiveSemigroup Rust_BLS12_381_G2_Point where
   (+) = runRustFun2 r_g2_add
 
 deriving newtype instance Zero Rust_BLS12_381_G2_JacobianPoint
+
 deriving newtype instance AdditiveMonoid Rust_BLS12_381_G2_JacobianPoint
 
 instance Zero Rust_BLS12_381_G2_Point where

--- a/symbolic-base/src/ZkFold/FFI/Rust/RustBLS.hs
+++ b/symbolic-base/src/ZkFold/FFI/Rust/RustBLS.hs
@@ -284,6 +284,15 @@ instance UnivariateRingPolyVec Fr (RustPolyVec Fr) where
   (+.) :: forall size. Fr -> RustPolyVec Fr size -> RustPolyVec Fr size
   (+.) = runRustFun2 r_poly_add_scalar
 
+  toPolyVec :: forall size. KnownNat size => V.Vector Fr -> RustPolyVec Fr size
+  toPolyVec a = h2r $ toPolyVec (r2h <$> a)
+
+  fromPolyVec :: forall size. KnownNat size => RustPolyVec Fr size -> V.Vector Fr
+  fromPolyVec a = h2r <$> fromPolyVec (r2h a)
+
+  evalPolyVec :: forall size. KnownNat size => RustPolyVec Fr size -> Fr -> Fr
+  evalPolyVec pv x = h2r $ evalPolyVec (r2h pv) (r2h x)
+
 instance UnivariateFieldPolyVec Fr (RustPolyVec Fr) where
   (./.) :: RustPolyVec Fr size -> RustPolyVec Fr size -> RustPolyVec Fr size
   (./.) = runRustFun2 r_poly_hdiv

--- a/symbolic-base/src/ZkFold/Protocol/IVC/Accumulator.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/Accumulator.hs
@@ -17,17 +17,17 @@ import Data.Functor.Rep (Representable (..), mzipWithRep)
 import GHC.Generics (Generic)
 import Prelude (type (~))
 
-import ZkFold.Algebra.Class (Ring, Scale, zero, Zero)
+import ZkFold.Algebra.Class (Ring, Scale, Zero, zero)
 import ZkFold.Algebra.Number (KnownNat, type (+), type (-))
 import ZkFold.Data.Bool (BoolType (..), and)
 import ZkFold.Data.Eq (Eq (..))
 import ZkFold.Data.Vector (Vector)
 import ZkFold.Protocol.IVC.AlgebraicMap (algebraicMap)
+import ZkFold.Protocol.IVC.Commit (HomomorphicCommit)
 import ZkFold.Protocol.IVC.Oracle
 import ZkFold.Protocol.IVC.Predicate (Predicate)
 import ZkFold.Symbolic.Data.Class (LayoutData (..), LayoutFunctor, SymbolicData (..))
 import ZkFold.Symbolic.MonadCircuit (ResidueField (..))
-import ZkFold.Protocol.IVC.Commit (HomomorphicCommit)
 
 -- import Prelude hiding (length, pi)
 

--- a/symbolic-base/src/ZkFold/Protocol/IVC/Accumulator.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/Accumulator.hs
@@ -120,7 +120,7 @@ emptyAccumulator hcommit phi =
       aiR = tabulate (const zero)
       aiMu = zero
       aiPI = tabulate (const zero)
-      aiE = hcommit $ algebraicMap @d phi aiPI accW aiR aiMu
+      aiE = hcommit (algebraicMap @d phi aiPI accW aiR aiMu) zero
       accX = AccumulatorInstance {_pi = LayoutData aiPI, _c = aiC, _r = aiR, _e = aiE, _mu = aiMu}
    in Accumulator accX accW
 

--- a/symbolic-base/src/ZkFold/Protocol/IVC/Accumulator.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/Accumulator.hs
@@ -17,7 +17,7 @@ import Data.Functor.Rep (Representable (..), mzipWithRep)
 import GHC.Generics (Generic)
 import Prelude (type (~))
 
-import ZkFold.Algebra.Class (Ring, Scale, zero, AdditiveMonoid)
+import ZkFold.Algebra.Class (Ring, Scale, zero, Zero)
 import ZkFold.Algebra.Number (KnownNat, type (+), type (-))
 import ZkFold.Data.Bool (BoolType (..), and)
 import ZkFold.Data.Eq (Eq (..))
@@ -105,7 +105,7 @@ emptyAccumulator
      , Foldable i
      , Representable p
      , Foldable p
-     , AdditiveMonoid c
+     , Zero c
      , Ring f
      , Scale a f
      , Binary (Rep i)
@@ -133,7 +133,7 @@ emptyAccumulatorInstance
      , Foldable i
      , Representable p
      , Foldable p
-     , AdditiveMonoid c
+     , Zero c
      , Ring f
      , Scale a f
      , Binary (Rep i)

--- a/symbolic-base/src/ZkFold/Protocol/IVC/Accumulator.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/Accumulator.hs
@@ -17,18 +17,17 @@ import Data.Functor.Rep (Representable (..), mzipWithRep)
 import GHC.Generics (Generic)
 import Prelude (type (~))
 
-import ZkFold.Algebra.Class (Ring, Scale, zero)
-import ZkFold.Algebra.EllipticCurve.Class (ScalarFieldOf)
+import ZkFold.Algebra.Class (Ring, Scale, zero, AdditiveMonoid)
 import ZkFold.Algebra.Number (KnownNat, type (+), type (-))
 import ZkFold.Data.Bool (BoolType (..), and)
 import ZkFold.Data.Eq (Eq (..))
 import ZkFold.Data.Vector (Vector)
 import ZkFold.Protocol.IVC.AlgebraicMap (algebraicMap)
-import ZkFold.Protocol.IVC.Commit (HomomorphicCommit (..))
 import ZkFold.Protocol.IVC.Oracle
 import ZkFold.Protocol.IVC.Predicate (Predicate)
 import ZkFold.Symbolic.Data.Class (LayoutData (..), LayoutFunctor, SymbolicData (..))
 import ZkFold.Symbolic.MonadCircuit (ResidueField (..))
+import ZkFold.Protocol.IVC.Commit (HomomorphicCommit)
 
 -- import Prelude hiding (length, pi)
 
@@ -106,16 +105,16 @@ emptyAccumulator
      , Foldable i
      , Representable p
      , Foldable p
-     , HomomorphicCommit c
+     , AdditiveMonoid c
      , Ring f
      , Scale a f
      , Binary (Rep i)
      , Binary (Rep p)
-     , f ~ ScalarFieldOf c
      )
-  => Predicate a i p
+  => HomomorphicCommit f c
+  -> Predicate a i p
   -> Accumulator k i c f
-emptyAccumulator phi =
+emptyAccumulator hcommit phi =
   let accW = tabulate (const zero)
       aiC = tabulate (const zero)
       aiR = tabulate (const zero)
@@ -134,13 +133,13 @@ emptyAccumulatorInstance
      , Foldable i
      , Representable p
      , Foldable p
-     , HomomorphicCommit c
+     , AdditiveMonoid c
      , Ring f
      , Scale a f
      , Binary (Rep i)
      , Binary (Rep p)
-     , f ~ ScalarFieldOf c
      )
-  => Predicate a i p
+  => HomomorphicCommit f c
+  -> Predicate a i p
   -> AccumulatorInstance k i c f
-emptyAccumulatorInstance phi = emptyAccumulator @d phi ^. x
+emptyAccumulatorInstance hcommit phi = emptyAccumulator @d hcommit phi ^. x

--- a/symbolic-base/src/ZkFold/Protocol/IVC/AccumulatorScheme.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/AccumulatorScheme.hs
@@ -10,9 +10,10 @@ import Data.Binary (Binary)
 import Data.Constraint (withDict)
 import Data.Constraint.Nat (plusMinusInverse1)
 import Data.Foldable (Foldable)
+import Data.Function (id, (.))
 import Data.Functor.Rep (Representable (..), mzipWithRep)
 import Data.Zip (Zip (..))
-import Prelude (fmap, ($), (<$>), Integer)
+import Prelude (Integer, fmap, ($), (<$>))
 import qualified Prelude as P
 
 import ZkFold.Algebra.Class
@@ -28,7 +29,6 @@ import ZkFold.Protocol.IVC.NARK (NARKInstanceProof (..), NARKProof (..))
 import ZkFold.Protocol.IVC.Oracle
 import ZkFold.Protocol.IVC.Predicate (Predicate)
 import ZkFold.Symbolic.Data.Class (LayoutData (LayoutData), layoutData)
-import Data.Function ((.), id)
 
 -- | Accumulator scheme for V_NARK as described in Chapter 3.4 of the Protostar paper
 data AccumulatorScheme d k i c pt f = AccumulatorScheme
@@ -56,7 +56,7 @@ a .- g = a .+ negate g
 instance AdditiveGroup g => AdditiveAction g g where
   (.+) = (+)
 
-newtype Act a = MkAct { runAct :: a -> a }
+newtype Act a = MkAct {runAct :: a -> a}
 
 instance AdditiveSemigroup (Act a) where
   MkAct f + MkAct g = MkAct (f . g)
@@ -68,6 +68,7 @@ instance {-# INCOHERENT #-} Scale k a => Scale k (Act a) where
   scale k = MkAct . (scale k .) . runAct
 
 instance Scale Natural a => AdditiveMonoid (Act a)
+
 instance (Scale Natural a, Scale Integer a) => AdditiveGroup (Act a) where
   negate = scale (-1 :: Integer)
 
@@ -101,107 +102,108 @@ accumulatorScheme
   -> HomomorphicCommit f c
   -> Predicate a i p
   -> AccumulatorScheme d k i c pt f
-accumulatorScheme hash hcommit phi = AccumulatorScheme
-  { prover = \(acc :: Accumulator k i c f)
-              (NARKInstanceProof pubi (NARKProof pi_x pi_w)) ->
-      let
-        r_0 :: f
-        r_0 = oracle hash (FoldableSource pubi)
+accumulatorScheme hash hcommit phi =
+  AccumulatorScheme
+    { prover =
+        \(acc :: Accumulator k i c f)
+         (NARKInstanceProof pubi (NARKProof pi_x pi_w)) ->
+            let
+              r_0 :: f
+              r_0 = oracle hash (FoldableSource pubi)
 
-        -- Fig. 3, step 1
-        r_i :: Vector (k - 1) f
-        r_i = transcript hash r_0 pi_x
+              -- Fig. 3, step 1
+              r_i :: Vector (k - 1) f
+              r_i = transcript hash r_0 pi_x
 
-        -- Fig. 3, step 2
+              -- Fig. 3, step 2
 
-        -- X + mu as a univariate polynomial
-        polyMu :: SimplePoly f (d + 1)
-        polyMu = polyVecLinear one (acc ^. x ^. mu)
+              -- X + mu as a univariate polynomial
+              polyMu :: SimplePoly f (d + 1)
+              polyMu = polyVecLinear one (acc ^. x ^. mu)
 
-        -- X * pi + pi' as a list of univariate polynomials
-        polyPi :: i (SimplePoly f (d + 1))
-        polyPi = mzipWithRep polyVecLinear pubi (layoutData $ acc ^. x ^. pi)
+              -- X * pi + pi' as a list of univariate polynomials
+              polyPi :: i (SimplePoly f (d + 1))
+              polyPi = mzipWithRep polyVecLinear pubi (layoutData $ acc ^. x ^. pi)
 
-        -- X * mi + mi'
-        polyW :: Vector k [SimplePoly f (d + 1)]
-        polyW = zipWith (zipWith polyVecLinear) pi_w (acc ^. w)
+              -- X * mi + mi'
+              polyW :: Vector k [SimplePoly f (d + 1)]
+              polyW = zipWith (zipWith polyVecLinear) pi_w (acc ^. w)
 
-        -- X * ri + ri'
-        polyR :: Vector (k - 1) (SimplePoly f (d + 1))
-        polyR = zipWith (P.flip polyVecLinear) (acc ^. x ^. r) r_i
+              -- X * ri + ri'
+              polyR :: Vector (k - 1) (SimplePoly f (d + 1))
+              polyR = zipWith (P.flip polyVecLinear) (acc ^. x ^. r) r_i
 
-        -- The @l x d+1@ matrix of coefficients
-        -- as a vector of @l@ univariate degree-@d@ polynomials
-        e_uni :: [Vector (d + 1) f]
-        e_uni = toVector <$> algebraicMap @d phi polyPi polyW polyR polyMu
+              -- The @l x d+1@ matrix of coefficients
+              -- as a vector of @l@ univariate degree-@d@ polynomials
+              e_uni :: [Vector (d + 1) f]
+              e_uni = toVector <$> algebraicMap @d phi polyPi polyW polyR polyMu
 
-        -- e_all are coefficients of degree-j homogenous polynomials
-        -- where j is from the range [0, d]
-        e_all :: Vector (d + 1) [f]
-        e_all = tabulate (\i -> fmap (`index` i) e_uni)
+              -- e_all are coefficients of degree-j homogenous polynomials
+              -- where j is from the range [0, d]
+              e_all :: Vector (d + 1) [f]
+              e_all = tabulate (\i -> fmap (`index` i) e_uni)
 
-        -- e_j are coefficients of degree-j homogenous polynomials
-        -- where j is from the range [1, d - 1]
-        e_j :: Vector (d - 1) [f]
-        e_j = withDict (plusMinusInverse1 @1 @d) $ tail $ init e_all
+              -- e_j are coefficients of degree-j homogenous polynomials
+              -- where j is from the range [1, d - 1]
+              e_j :: Vector (d - 1) [f]
+              e_j = withDict (plusMinusInverse1 @1 @d) $ tail $ init e_all
 
-        -- Fig. 3, step 3
-        pf = MkAct . hcommit <$> e_j
+              -- Fig. 3, step 3
+              pf = MkAct . hcommit <$> e_j
 
-        -- Fig. 3, step 4
-        alpha :: f
-        alpha = oracle hash (acc ^. x, FoldableSource pubi, pi_x, (zero @c .+) <$> pf)
+              -- Fig. 3, step 4
+              alpha :: f
+              alpha = oracle hash (acc ^. x, FoldableSource pubi, pi_x, (zero @c .+) <$> pf)
 
-        -- Fig. 3, steps 5, 6
-        mu' = alpha + acc ^. x ^. mu
-        pi'' = mzipWithRep (+) (fmap (* alpha) pubi) (layoutData $ acc ^. x ^. pi)
-        ri'' = scale alpha r_i + acc ^. x ^. r
-        ci'' = zipWith (.+) (acc ^. x ^. c) (fmap (scale alpha) pi_x)
-        m_i'' = zipWith (+) (scale alpha pi_w) (acc ^. w)
+              -- Fig. 3, steps 5, 6
+              mu' = alpha + acc ^. x ^. mu
+              pi'' = mzipWithRep (+) (fmap (* alpha) pubi) (layoutData $ acc ^. x ^. pi)
+              ri'' = scale alpha r_i + acc ^. x ^. r
+              ci'' = zipWith (.+) (acc ^. x ^. c) (fmap (scale alpha) pi_x)
+              m_i'' = zipWith (+) (scale alpha pi_w) (acc ^. w)
 
-        -- Fig. 3, step 7
-        eCapital' = (acc ^. x ^. e) .+ sum (mapWithIx (\i a -> scale (alpha ^ (i + 1)) a) pf)
-       in
-        ( Accumulator
-            (AccumulatorInstance (LayoutData pi'') ci'' ri'' eCapital' mu')
-            m_i''
-        , pf)
+              -- Fig. 3, step 7
+              eCapital' = (acc ^. x ^. e) .+ sum (mapWithIx (\i a -> scale (alpha ^ (i + 1)) a) pf)
+             in
+              ( Accumulator
+                  (AccumulatorInstance (LayoutData pi'') ci'' ri'' eCapital' mu')
+                  m_i''
+              , pf
+              )
+    , verifier = \pubi pi_x acc pf ->
+        let
+          r_0 :: f
+          r_0 = oracle hash (FoldableSource pubi)
 
-  , verifier = \pubi pi_x acc pf ->
-      let
-        r_0 :: f
-        r_0 = oracle hash (FoldableSource pubi)
+          -- Fig. 4, step 1
+          r_i :: Vector (k - 1) f
+          r_i = transcript hash r_0 pi_x
 
-        -- Fig. 4, step 1
-        r_i :: Vector (k - 1) f
-        r_i = transcript hash r_0 pi_x
+          -- Fig. 4, step 2
+          alpha :: f
+          alpha = oracle hash (acc, FoldableSource pubi, pi_x, pf)
 
-        -- Fig. 4, step 2
-        alpha :: f
-        alpha = oracle hash (acc, FoldableSource pubi, pi_x, pf)
+          -- Fig. 4, steps 3-4
+          mu' = alpha + acc ^. mu
+          pi'' = mzipWithRep (+) (fmap (* alpha) pubi) (layoutData $ acc ^. pi)
+          ri'' = zipWith (+) (scale alpha r_i) (acc ^. r)
+          ci'' = zipWith (.+) (acc ^. c) (fmap (scale alpha) pi_x)
 
-        -- Fig. 4, steps 3-4
-        mu' = alpha + acc ^. mu
-        pi'' = mzipWithRep (+) (fmap (* alpha) pubi) (layoutData $ acc ^. pi)
-        ri'' = zipWith (+) (scale alpha r_i) (acc ^. r)
-        ci'' = zipWith (.+) (acc ^. c) (fmap (scale alpha) pi_x)
+          -- Fig 4, step 5
+          e' = (acc ^. e) .+ sum (mapWithIx (\i a -> scale (alpha ^ (i + 1)) a) pf)
+         in
+          AccumulatorInstance {_pi = LayoutData pi'', _c = ci'', _r = ri'', _e = e', _mu = mu'}
+    , decider = \acc ->
+        let
+          -- Fig. 5, step 1
+          commitsDiff = zipWith hcommit (negate <$> acc ^. w) (acc ^. x ^. c)
 
-        -- Fig 4, step 5
-        e' = (acc ^. e) .+ sum (mapWithIx (\i a -> scale (alpha ^ (i + 1)) a) pf)
-       in
-        AccumulatorInstance {_pi = LayoutData pi'', _c = ci'', _r = ri'', _e = e', _mu = mu'}
+          -- Fig. 5, step 2
+          err :: [f]
+          err = algebraicMap @d phi (layoutData $ acc ^. x ^. pi) (acc ^. w) (acc ^. x ^. r) (acc ^. x ^. mu)
 
-  , decider = \acc ->
-      let
-        -- Fig. 5, step 1
-        commitsDiff = zipWith hcommit (negate <$> acc ^. w) (acc ^. x ^. c)
-
-        -- Fig. 5, step 2
-        err :: [f]
-        err = algebraicMap @d phi (layoutData $ acc ^. x ^. pi) (acc ^. w) (acc ^. x ^. r) (acc ^. x ^. mu)
-
-        -- Fig. 5, step 3
-        eDiff = hcommit (negate <$> err) (acc ^. x ^. e)
-       in
-        (commitsDiff, eDiff)
-  }
+          -- Fig. 5, step 3
+          eDiff = hcommit (negate <$> err) (acc ^. x ^. e)
+         in
+          (commitsDiff, eDiff)
+    }

--- a/symbolic-base/src/ZkFold/Protocol/IVC/AccumulatorScheme.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/AccumulatorScheme.hs
@@ -194,14 +194,14 @@ accumulatorScheme hash hcommit phi = AccumulatorScheme
   , decider = \acc ->
       let
         -- Fig. 5, step 1
-        commitsDiff = zipWith hcommit (acc ^. w) (acc ^. x ^. c)
+        commitsDiff = zipWith hcommit (negate <$> acc ^. w) (acc ^. x ^. c)
 
         -- Fig. 5, step 2
         err :: [f]
         err = algebraicMap @d phi (layoutData $ acc ^. x ^. pi) (acc ^. w) (acc ^. x ^. r) (acc ^. x ^. mu)
 
         -- Fig. 5, step 3
-        eDiff = hcommit err (acc ^. x ^. e)
+        eDiff = hcommit (negate <$> err) (acc ^. x ^. e)
        in
         (commitsDiff, eDiff)
   }

--- a/symbolic-base/src/ZkFold/Protocol/IVC/AccumulatorScheme.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/AccumulatorScheme.hs
@@ -11,18 +11,17 @@ import Data.Constraint.Nat (plusMinusInverse1)
 import Data.Foldable (Foldable)
 import Data.Functor.Rep (Representable (..), mzipWithRep)
 import Data.Zip (Zip (..))
-import Prelude (fmap, ($), (<$>), type (~))
+import Prelude (fmap, ($), (<$>))
 import qualified Prelude as P
 
 import ZkFold.Algebra.Class
-import ZkFold.Algebra.EllipticCurve.Class (ScalarFieldOf)
 import ZkFold.Algebra.Number
 import ZkFold.Algebra.Polynomial.Univariate (polyVecLinear)
 import ZkFold.Algebra.Polynomial.Univariate.Simple (SimplePoly, toVector)
 import ZkFold.Data.Vector (Vector, init, mapWithIx, tail)
 import ZkFold.Protocol.IVC.Accumulator
 import ZkFold.Protocol.IVC.AlgebraicMap (algebraicMap)
-import ZkFold.Protocol.IVC.Commit (HomomorphicCommit (..))
+import ZkFold.Protocol.IVC.Commit (HomomorphicCommit)
 import ZkFold.Protocol.IVC.FiatShamir (transcript)
 import ZkFold.Protocol.IVC.NARK (NARKInstanceProof (..), NARKProof (..))
 import ZkFold.Protocol.IVC.Oracle
@@ -56,19 +55,19 @@ accumulatorScheme
      , Foldable p
      , OracleSource f f
      , OracleSource f c
-     , HomomorphicCommit c
+     , AdditiveGroup c
      , Field f
      , Scale a f
      , Scale a (SimplePoly f (d + 1))
      , Scale f c
      , Binary (Rep i)
      , Binary (Rep p)
-     , f ~ ScalarFieldOf c
      )
   => Hasher
+  -> HomomorphicCommit f c
   -> Predicate a i p
   -> AccumulatorScheme d k i c f
-accumulatorScheme hash phi =
+accumulatorScheme hash hcommit phi =
   let
     prover acc (NARKInstanceProof pubi (NARKProof pi_x pi_w)) =
       let

--- a/symbolic-base/src/ZkFold/Protocol/IVC/AccumulatorScheme.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/AccumulatorScheme.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {- HLINT ignore "Redundant ^." -}
 
@@ -11,7 +12,7 @@ import Data.Constraint.Nat (plusMinusInverse1)
 import Data.Foldable (Foldable)
 import Data.Functor.Rep (Representable (..), mzipWithRep)
 import Data.Zip (Zip (..))
-import Prelude (fmap, ($), (<$>))
+import Prelude (fmap, ($), (<$>), Integer)
 import qualified Prelude as P
 
 import ZkFold.Algebra.Class
@@ -27,26 +28,54 @@ import ZkFold.Protocol.IVC.NARK (NARKInstanceProof (..), NARKProof (..))
 import ZkFold.Protocol.IVC.Oracle
 import ZkFold.Protocol.IVC.Predicate (Predicate)
 import ZkFold.Symbolic.Data.Class (LayoutData (LayoutData), layoutData)
+import Data.Function ((.), id)
 
 -- | Accumulator scheme for V_NARK as described in Chapter 3.4 of the Protostar paper
-data AccumulatorScheme d k i c f = AccumulatorScheme
+data AccumulatorScheme d k i c pt f = AccumulatorScheme
   { prover
       :: Accumulator k i c f -- accumulator
-      -> NARKInstanceProof k i c f -- instance-proof pair (pi, π)
-      -> (Accumulator k i c f, Vector (d - 1) c) -- updated accumulator and accumulation proof
+      -> NARKInstanceProof k i pt f -- instance-proof pair (pi, π)
+      -> (Accumulator k i c f, Vector (d - 1) (Act c)) -- updated accumulator and accumulation proof
   , verifier
       :: i f -- Public input
-      -> Vector k c -- NARK proof π.x
+      -> Vector k pt -- NARK proof π.x
       -> AccumulatorInstance k i c f -- accumulator instance acc.x
-      -> Vector (d - 1) c -- accumulation proof E_j
+      -> Vector (d - 1) pt -- accumulation proof E_j
       -> AccumulatorInstance k i c f -- updated accumulator instance acc'.x
   , decider
       :: Accumulator k i c f -- final accumulator
       -> (Vector k c, c) -- returns zeros if the final accumulator is valid
   }
 
+class AdditiveGroup g => AdditiveAction g a where
+  (.+) :: a -> g -> a
+
+(.-) :: AdditiveAction g a => a -> g -> a
+a .- g = a .+ negate g
+
+instance AdditiveGroup g => AdditiveAction g g where
+  (.+) = (+)
+
+newtype Act a = MkAct { runAct :: a -> a }
+
+instance AdditiveSemigroup (Act a) where
+  MkAct f + MkAct g = MkAct (f . g)
+
+instance Zero (Act a) where
+  zero = MkAct id
+
+instance {-# INCOHERENT #-} Scale k a => Scale k (Act a) where
+  scale k = MkAct . (scale k .) . runAct
+
+instance Scale Natural a => AdditiveMonoid (Act a)
+instance (Scale Natural a, Scale Integer a) => AdditiveGroup (Act a) where
+  negate = scale (-1 :: Integer)
+
+instance (Scale Natural a, Scale Integer a) => AdditiveAction (Act a) a where
+  a .+ MkAct f = f a
+
 accumulatorScheme
-  :: forall d c k a i p f
+  :: forall d c k a i p f pt
    . ( KnownNat (d - 1)
      , KnownNat (d + 1)
      , Representable i
@@ -55,21 +84,26 @@ accumulatorScheme
      , Foldable p
      , OracleSource f f
      , OracleSource f c
-     , AdditiveGroup c
+     , OracleSource f pt
+     , AdditiveAction pt c
+     , Zero c
+     , Scale Natural c
+     , Scale Integer c
+     , Scale f c
      , Field f
      , Scale a f
      , Scale a (SimplePoly f (d + 1))
-     , Scale f c
+     , Scale f pt
      , Binary (Rep i)
      , Binary (Rep p)
      )
   => Hasher
   -> HomomorphicCommit f c
   -> Predicate a i p
-  -> AccumulatorScheme d k i c f
-accumulatorScheme hash hcommit phi =
-  let
-    prover acc (NARKInstanceProof pubi (NARKProof pi_x pi_w)) =
+  -> AccumulatorScheme d k i c pt f
+accumulatorScheme hash hcommit phi = AccumulatorScheme
+  { prover = \(acc :: Accumulator k i c f)
+              (NARKInstanceProof pubi (NARKProof pi_x pi_w)) ->
       let
         r_0 :: f
         r_0 = oracle hash (FoldableSource pubi)
@@ -112,25 +146,28 @@ accumulatorScheme hash hcommit phi =
         e_j = withDict (plusMinusInverse1 @1 @d) $ tail $ init e_all
 
         -- Fig. 3, step 3
-        pf = hcommit <$> e_j
+        pf = MkAct . hcommit <$> e_j
 
         -- Fig. 3, step 4
         alpha :: f
-        alpha = oracle hash (acc ^. x, FoldableSource pubi, pi_x, pf)
+        alpha = oracle hash (acc ^. x, FoldableSource pubi, pi_x, (zero @c .+) <$> pf)
 
         -- Fig. 3, steps 5, 6
         mu' = alpha + acc ^. x ^. mu
         pi'' = mzipWithRep (+) (fmap (* alpha) pubi) (layoutData $ acc ^. x ^. pi)
         ri'' = scale alpha r_i + acc ^. x ^. r
-        ci'' = fmap (scale alpha) pi_x + acc ^. x ^. c
+        ci'' = zipWith (.+) (acc ^. x ^. c) (fmap (scale alpha) pi_x)
         m_i'' = zipWith (+) (scale alpha pi_w) (acc ^. w)
 
         -- Fig. 3, step 7
-        eCapital' = acc ^. x ^. e + sum (mapWithIx (\i a -> scale (alpha ^ (i + 1)) a) pf)
+        eCapital' = (acc ^. x ^. e) .+ sum (mapWithIx (\i a -> scale (alpha ^ (i + 1)) a) pf)
        in
-        (Accumulator (AccumulatorInstance (LayoutData pi'') ci'' ri'' eCapital' mu') m_i'', pf)
+        ( Accumulator
+            (AccumulatorInstance (LayoutData pi'') ci'' ri'' eCapital' mu')
+            m_i''
+        , pf)
 
-    verifier pubi pi_x acc pf =
+  , verifier = \pubi pi_x acc pf ->
       let
         r_0 :: f
         r_0 = oracle hash (FoldableSource pubi)
@@ -147,25 +184,24 @@ accumulatorScheme hash hcommit phi =
         mu' = alpha + acc ^. mu
         pi'' = mzipWithRep (+) (fmap (* alpha) pubi) (layoutData $ acc ^. pi)
         ri'' = zipWith (+) (scale alpha r_i) (acc ^. r)
-        ci'' = zipWith (+) (fmap (scale alpha) pi_x) (acc ^. c)
+        ci'' = zipWith (.+) (acc ^. c) (fmap (scale alpha) pi_x)
 
         -- Fig 4, step 5
-        e' = acc ^. e + sum (mapWithIx (\i a -> scale (alpha ^ (i + 1)) a) pf)
+        e' = (acc ^. e) .+ sum (mapWithIx (\i a -> scale (alpha ^ (i + 1)) a) pf)
        in
         AccumulatorInstance {_pi = LayoutData pi'', _c = ci'', _r = ri'', _e = e', _mu = mu'}
 
-    decider acc =
+  , decider = \acc ->
       let
         -- Fig. 5, step 1
-        commitsDiff = zipWith (\cm m_acc -> cm - hcommit m_acc) (acc ^. x ^. c) (acc ^. w)
+        commitsDiff = zipWith hcommit (acc ^. w) (acc ^. x ^. c)
 
         -- Fig. 5, step 2
         err :: [f]
         err = algebraicMap @d phi (layoutData $ acc ^. x ^. pi) (acc ^. w) (acc ^. x ^. r) (acc ^. x ^. mu)
 
         -- Fig. 5, step 3
-        eDiff = (acc ^. x ^. e) - hcommit err
+        eDiff = hcommit err (acc ^. x ^. e)
        in
         (commitsDiff, eDiff)
-   in
-    AccumulatorScheme prover verifier decider
+  }

--- a/symbolic-base/src/ZkFold/Protocol/IVC/Commit.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/Commit.hs
@@ -37,8 +37,8 @@ instance
     let x = fromConstant @Natural $ unLittleEndian $ fromJust $ fromByteString $ hash "42" :: ScalarFieldOf g
      in iterate (scale x) pointGen
 
--- | Homomorphic commitment scheme, i.e. (hcommit x) * (hcommit y) == hcommit (x + y)
-type HomomorphicCommit a g = [a] -> g
+-- | Homomorphic commitment scheme, i.e. hcommit x . hcommit y == hcommit (x + y)
+type HomomorphicCommit a g = [a] -> g -> g
 
 cyclicCommit :: CyclicGroup g => HomomorphicCommit (ScalarFieldOf g) g
-cyclicCommit v = sum $ zipWith scale v groupElements
+cyclicCommit v g = sum (zipWith scale v groupElements) + g

--- a/symbolic-base/src/ZkFold/Protocol/IVC/Commit.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/Commit.hs
@@ -2,8 +2,9 @@
 
 module ZkFold.Protocol.IVC.Commit (
   Commit,
+  HomomorphicCommit,
   oracleCommitment,
-  HomomorphicCommit (..),
+  cyclicCommit,
   PedersonSetup (..),
 ) where
 
@@ -37,11 +38,7 @@ instance
      in iterate (scale x) pointGen
 
 -- | Homomorphic commitment scheme, i.e. (hcommit x) * (hcommit y) == hcommit (x + y)
-class CyclicGroup g => HomomorphicCommit g where
-  hcommit :: [ScalarFieldOf g] -> g
+type HomomorphicCommit a g = [a] -> g
 
-instance
-  CyclicGroup g
-  => HomomorphicCommit g
-  where
-  hcommit v = sum $ zipWith (scale @(ScalarFieldOf g)) v groupElements
+cyclicCommit :: CyclicGroup g => HomomorphicCommit (ScalarFieldOf g) g
+cyclicCommit v = sum $ zipWith scale v groupElements

--- a/symbolic-base/src/ZkFold/Protocol/IVC/CommitOpen.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/CommitOpen.hs
@@ -6,10 +6,9 @@ import Data.Zip (zipWith)
 import Prelude hiding (Num (..), length, pi, tail, zipWith, (&&))
 
 import ZkFold.Algebra.Class (AdditiveGroup (..))
-import ZkFold.Algebra.EllipticCurve.Class (CyclicGroup (ScalarFieldOf))
 import ZkFold.Algebra.Number (Natural, type (-))
 import ZkFold.Data.Vector (Vector)
-import ZkFold.Protocol.IVC.Commit (HomomorphicCommit (hcommit))
+import ZkFold.Protocol.IVC.Commit (HomomorphicCommit)
 import ZkFold.Protocol.IVC.SpecialSound (SpecialSoundProtocol (..))
 
 data CommitOpen k i p c f = CommitOpen
@@ -43,10 +42,11 @@ data CommitOpen k i p c f = CommitOpen
   }
 
 commitOpen
-  :: (HomomorphicCommit c, f ~ ScalarFieldOf c)
-  => SpecialSoundProtocol k i p f
+  :: AdditiveGroup c
+  => HomomorphicCommit f c
+  -> SpecialSoundProtocol k i p f
   -> CommitOpen k i p c f
-commitOpen SpecialSoundProtocol {..} =
+commitOpen hcommit SpecialSoundProtocol {..} =
   CommitOpen
     { input = input
     , prover = \pi0 w r i ->

--- a/symbolic-base/src/ZkFold/Protocol/IVC/CommitOpen.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/CommitOpen.hs
@@ -2,14 +2,14 @@
 
 module ZkFold.Protocol.IVC.CommitOpen where
 
+import Data.Functor ((<&>))
 import Prelude hiding (Num (..), length, pi, tail, zipWith, (&&))
 
+import ZkFold.Algebra.Class (AdditiveGroup, Zero, negate, zero)
 import ZkFold.Algebra.Number (Natural, type (-))
 import ZkFold.Data.Vector (Vector)
 import ZkFold.Protocol.IVC.Commit (HomomorphicCommit)
 import ZkFold.Protocol.IVC.SpecialSound (SpecialSoundProtocol (..))
-import ZkFold.Algebra.Class (zero, negate, Zero, AdditiveGroup)
-import Data.Functor ((<&>))
 
 data CommitOpen k i p c f = CommitOpen
   { input

--- a/symbolic-base/src/ZkFold/Protocol/IVC/FiatShamir.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/FiatShamir.hs
@@ -39,7 +39,7 @@ data FiatShamir k i p c f = FiatShamir
       -- \^ prover messages
       -> Vector (k - 1) f
       -- \^ random challenges
-      -> (Vector k c, [f])
+      -> (Vector k (c, c), [f])
   -- ^ verifier output
   }
 

--- a/symbolic-base/src/ZkFold/Protocol/IVC/FiatShamir.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/FiatShamir.hs
@@ -39,7 +39,7 @@ data FiatShamir k i p c f = FiatShamir
       -- \^ prover messages
       -> Vector (k - 1) f
       -- \^ random challenges
-      -> (Vector k (c, c), [f])
+      -> (Vector k c, [f])
   -- ^ verifier output
   }
 

--- a/symbolic-base/src/ZkFold/Protocol/IVC/ForeignField.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/ForeignField.hs
@@ -41,8 +41,10 @@ instance (KnownNat q, Euclidean i) => Exponent (ForeignField q i) Natural where
 instance (KnownNat q, Euclidean i) => AdditiveSemigroup (ForeignField q i) where
   ForeignField f + ForeignField g = ForeignField ((f + g) `mod` fromConstant (value @q))
 
-instance (KnownNat q, Euclidean i) => AdditiveMonoid (ForeignField q i) where
+instance Zero i => Zero (ForeignField q i) where
   zero = ForeignField zero
+
+instance (KnownNat q, Euclidean i) => AdditiveMonoid (ForeignField q i)
 
 instance (KnownNat q, Euclidean i) => AdditiveGroup (ForeignField q i) where
   negate (ForeignField f) = ForeignField (negate f `mod` fromConstant (value @q))

--- a/symbolic-base/src/ZkFold/Protocol/IVC/OperationRecord.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/OperationRecord.hs
@@ -64,6 +64,15 @@ instance
      in addOp (Left c) record
 
 instance
+  ( SymbolicData c
+  , SymbolicData s
+  , Context c ~ ctx
+  , Context s ~ ctx
+  , Zero c
+  ) => Zero (OperationRecord c s ctx) where
+  zero = newRec zero
+
+instance
   ( AdditiveMonoid c
   , Scale s c
   , SymbolicData c
@@ -73,8 +82,6 @@ instance
   , FromConstant Natural s
   )
   => AdditiveMonoid (OperationRecord c s ctx)
-  where
-  zero = newRec zero
 
 instance
   ( AdditiveMonoid c

--- a/symbolic-base/src/ZkFold/Protocol/IVC/OperationRecord.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/OperationRecord.hs
@@ -1,17 +1,17 @@
 module ZkFold.Protocol.IVC.OperationRecord where
 
 import Data.Bifunctor (Bifunctor (..))
+import Data.Bool (Bool)
+import Data.Eq (Eq (..))
 import Data.Functor (Functor, fmap, (<$>))
 import Data.List ((++))
 import Data.Tuple (snd)
 import Prelude (Integer)
 
 import ZkFold.Algebra.Class
-import ZkFold.Protocol.IVC.AccumulatorScheme (AdditiveAction (..))
 import ZkFold.Algebra.EllipticCurve.Class (CyclicGroup (..))
-import Data.Eq (Eq (..))
 import ZkFold.Data.Bool
-import Data.Bool (Bool)
+import ZkFold.Protocol.IVC.AccumulatorScheme (AdditiveAction (..))
 
 data Operands s c = Addends c c | Scaling s c deriving Functor
 
@@ -45,10 +45,11 @@ record :: (Operands s c, c) -> [(Operands s c, c)] -> OperationRecord s c
 record res log = OperationRecord (snd res) (res : log)
 
 instance Bifunctor OperationRecord where
-  first f OperationRecord {..} = OperationRecord
-    { opValue = opValue
-    , opLog = first (first f) <$> opLog
-    }
+  first f OperationRecord {..} =
+    OperationRecord
+      { opValue = opValue
+      , opLog = first (first f) <$> opLog
+      }
   second = fmap
 
 instance Zero c => Zero (OperationRecord s c) where
@@ -57,11 +58,14 @@ instance Zero c => Zero (OperationRecord s c) where
 instance AdditiveSemigroup c => AdditiveSemigroup (OperationRecord s c) where
   OperationRecord a l + OperationRecord b m = addends a b `record` (l ++ m)
 
-instance (Semiring s, AdditiveMonoid c, Scale s c) =>
-  AdditiveMonoid (OperationRecord s c)
+instance
+  (Semiring s, AdditiveMonoid c, Scale s c)
+  => AdditiveMonoid (OperationRecord s c)
 
-instance (Ring s, AdditiveMonoid c, Scale s c) =>
-  AdditiveGroup (OperationRecord s c) where
+instance
+  (Ring s, AdditiveMonoid c, Scale s c)
+  => AdditiveGroup (OperationRecord s c)
+  where
   negate = scale (-1 :: Integer)
 
 instance AdditiveGroup c => AdditiveAction c (OperationRecord s c) where

--- a/symbolic-base/src/ZkFold/Protocol/IVC/OperationRecord.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/OperationRecord.hs
@@ -11,7 +11,6 @@ import Prelude (Integer, ($), type (~))
 import ZkFold.Algebra.Class
 import ZkFold.Algebra.EllipticCurve.Class (CyclicGroup (..))
 import ZkFold.Algebra.Number (Natural)
-import ZkFold.Protocol.IVC.Commit (HomomorphicCommit (..))
 import ZkFold.Symbolic.Data.Class (SymbolicData (..), withoutConstraints)
 import ZkFold.Symbolic.Data.List (List, emptyList, head, (.:))
 import ZkFold.Symbolic.Data.Sum (Sum, inject, match)
@@ -30,7 +29,8 @@ newRec
 newRec c = OperationRecord $ inject (Left (c, c, c)) .: emptyList
 
 addOp
-  :: (SymbolicData c, SymbolicData s, Context c ~ ctx, Context s ~ ctx, HomomorphicCommit c, Scale s c)
+  :: (SymbolicData c, SymbolicData s, Context c ~ ctx, Context s ~ ctx)
+  => (AdditiveSemigroup c, Scale s c)
   => Either c s
   -> OperationRecord c s ctx
   -> OperationRecord c s ctx
@@ -49,8 +49,9 @@ addOp op' (OperationRecord ops) =
           .: ops
 
 instance
-  (HomomorphicCommit c, Scale s c, SymbolicData c, Context c ~ ctx, SymbolicData s, Context s ~ ctx)
-  => AdditiveSemigroup (OperationRecord c s ctx)
+  ( SymbolicData c, Context c ~ ctx, SymbolicData s, Context s ~ ctx
+  , AdditiveSemigroup c, Scale s c
+  ) => AdditiveSemigroup (OperationRecord c s ctx)
   where
   OperationRecord ops + record =
     let c =
@@ -63,7 +64,7 @@ instance
      in addOp (Left c) record
 
 instance
-  ( HomomorphicCommit c
+  ( AdditiveMonoid c
   , Scale s c
   , SymbolicData c
   , Context c ~ ctx
@@ -76,7 +77,7 @@ instance
   zero = newRec zero
 
 instance
-  ( HomomorphicCommit c
+  ( AdditiveMonoid c
   , Scale s c
   , SymbolicData c
   , Context c ~ ctx
@@ -90,13 +91,14 @@ instance
   negate = scale (-1 :: Integer)
 
 instance
-  (HomomorphicCommit c, Scale s c, SymbolicData c, Context c ~ ctx, SymbolicData s, Context s ~ ctx, s ~ ScalarFieldOf c)
-  => Scale s (OperationRecord c s ctx)
+  ( AdditiveSemigroup c, Scale s c, SymbolicData c, Context c ~ ctx
+  , SymbolicData s, Context s ~ ctx, s ~ ScalarFieldOf c
+  ) => Scale s (OperationRecord c s ctx)
   where
   scale s = addOp (Right s)
 
 instance
-  ( HomomorphicCommit c
+  ( AdditiveSemigroup c
   , Scale s c
   , SymbolicData c
   , Context c ~ ctx
@@ -109,7 +111,7 @@ instance
   scale n = addOp (Right $ fromConstant n)
 
 instance
-  ( HomomorphicCommit c
+  ( AdditiveSemigroup c
   , Scale s c
   , SymbolicData c
   , Context c ~ ctx
@@ -122,7 +124,7 @@ instance
   scale n = addOp (Right $ fromConstant n)
 
 instance
-  ( HomomorphicCommit c
+  ( CyclicGroup c
   , Scale s c
   , SymbolicData c
   , Context c ~ ctx

--- a/symbolic-base/src/ZkFold/Protocol/IVC/RecursiveFunction.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/RecursiveFunction.hs
@@ -3,14 +3,13 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
-
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module ZkFold.Protocol.IVC.RecursiveFunction where
 
 import Data.Binary (Binary (..))
 import Data.Foldable (toList)
-import Data.Function ((.), ($))
+import Data.Function (($), (.))
 import GHC.Generics (Generic, Par1, (:*:))
 import Prelude ((<$>), type (~))
 
@@ -19,20 +18,20 @@ import ZkFold.Algebra.EllipticCurve.Class (CyclicGroup (..))
 import ZkFold.Algebra.Number (KnownNat, type (+), type (-))
 import ZkFold.ArithmeticCircuit.Context (CircuitContext)
 import ZkFold.Data.Empty (empty)
+import ZkFold.Data.HFunctor (hmap)
 import ZkFold.Data.Orphans ()
 import ZkFold.Data.Package (unpacked)
+import ZkFold.Data.Product (fstP, sndP)
 import ZkFold.Data.Vector (Vector)
 import ZkFold.Protocol.IVC.Accumulator hiding (pi, x)
 import ZkFold.Protocol.IVC.AccumulatorScheme (AccumulatorScheme (..), accumulatorScheme)
 import ZkFold.Protocol.IVC.Commit (HomomorphicCommit)
 import ZkFold.Protocol.IVC.Oracle
 import ZkFold.Protocol.IVC.Predicate (Predicate (..), StepFunction, predicate)
-import ZkFold.Symbolic.Class (Arithmetic, Symbolic (witnessF, BaseField))
+import ZkFold.Symbolic.Class (Arithmetic, Symbolic (BaseField, witnessF))
 import ZkFold.Symbolic.Data.Bool (Bool, bool)
 import ZkFold.Symbolic.Data.Class (LayoutFunctor, SymbolicData (..))
 import ZkFold.Symbolic.Data.FieldElement (FieldElement (..), fieldElements)
-import ZkFold.Data.HFunctor (hmap)
-import ZkFold.Data.Product (fstP, sndP)
 
 -- | Public input to the recursive function
 type RecursiveI i = i :*: Par1
@@ -40,13 +39,14 @@ type RecursiveI i = i :*: Par1
 newtype DataSource c = DataSource {dataSource :: c}
   deriving newtype
     ( AdditiveGroup
-    , Zero
     , AdditiveSemigroup
     , CyclicGroup
     , SymbolicData
+    , Zero
     )
 
 deriving newtype instance AdditiveMonoid c => AdditiveMonoid (DataSource c)
+
 deriving instance {-# INCOHERENT #-} Scale a c => Scale a (DataSource c)
 
 instance
@@ -77,7 +77,7 @@ instance
 
 type RecursiveP d k i p c =
   Layout (RecursivePayload d k i p c)
-  :*: Payload (RecursivePayload d k i p c)
+    :*: Payload (RecursivePayload d k i p c)
 
 type RecursiveFunction d k a i p c =
   StepFunction a (RecursiveI i) (RecursiveP d k i p c)
@@ -119,8 +119,8 @@ recursiveFunction hash hcommit func =
     -- A helper function to derive the accumulator scheme
     func' :: RecursiveFunction d k a i p c
     func'
-      (restore . (, empty) -> (x, h :: FieldElement (Context c)))
-      (restoreP ->
+      (restore . (,empty) -> (x, h :: FieldElement (Context c)))
+      ( restoreP ->
           ( RecursivePayload u _ _ _ _
               :: RecursivePayload d k i p c
             )

--- a/symbolic-base/src/ZkFold/Protocol/IVC/RecursiveFunction.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/RecursiveFunction.hs
@@ -10,7 +10,7 @@ module ZkFold.Protocol.IVC.RecursiveFunction where
 
 import Data.Binary (Binary (..))
 import Data.Foldable (toList)
-import Data.Function ((.))
+import Data.Function ((.), ($))
 import GHC.Generics (Generic, Par1, (:*:))
 import Prelude ((<$>), type (~))
 
@@ -18,7 +18,7 @@ import ZkFold.Algebra.Class
 import ZkFold.Algebra.EllipticCurve.Class (CyclicGroup (..))
 import ZkFold.Algebra.Number (KnownNat, type (+), type (-))
 import ZkFold.ArithmeticCircuit.Context (CircuitContext)
-import ZkFold.Data.Empty (Empty, empty)
+import ZkFold.Data.Empty (empty)
 import ZkFold.Data.Orphans ()
 import ZkFold.Data.Package (unpacked)
 import ZkFold.Data.Vector (Vector)
@@ -27,10 +27,12 @@ import ZkFold.Protocol.IVC.AccumulatorScheme (AccumulatorScheme (..), accumulato
 import ZkFold.Protocol.IVC.Commit (HomomorphicCommit)
 import ZkFold.Protocol.IVC.Oracle
 import ZkFold.Protocol.IVC.Predicate (Predicate (..), StepFunction, predicate)
-import ZkFold.Symbolic.Class (Arithmetic)
+import ZkFold.Symbolic.Class (Arithmetic, Symbolic (witnessF, BaseField))
 import ZkFold.Symbolic.Data.Bool (Bool, bool)
 import ZkFold.Symbolic.Data.Class (LayoutFunctor, SymbolicData (..))
 import ZkFold.Symbolic.Data.FieldElement (FieldElement (..), fieldElements)
+import ZkFold.Data.HFunctor (hmap)
+import ZkFold.Data.Product (fstP, sndP)
 
 -- | Public input to the recursive function
 type RecursiveI i = i :*: Par1
@@ -73,24 +75,24 @@ instance
   )
   => SymbolicData (RecursivePayload d k i p c)
 
-type RecursiveP d k i p c = Layout (RecursivePayload d k i p c)
+type RecursiveP d k i p c =
+  Layout (RecursivePayload d k i p c)
+  :*: Payload (RecursivePayload d k i p c)
 
 type RecursiveFunction d k a i p c =
   StepFunction a (RecursiveI i) (RecursiveP d k i p c)
 
-type FieldAssumptions a c =
-  ( Arithmetic a
-  , Binary a
-  , SymbolicData c
-  , Context c ~ CircuitContext a
-  , Empty (Payload c)
+instance OracleSource (FieldElement ctx) (FieldElement ctx) where
+  source = (: [])
+
+type IsRecursivePoint c =
+  ( SymbolicData c
+  , Context c ~ CircuitContext (BaseField (Context c))
+  , LayoutFunctor (Payload c)
   , Scale (FieldElement (Context c)) c
   , AdditiveGroup c
   , OracleSource (FieldElement (Context c)) c
   )
-
-instance OracleSource (FieldElement ctx) (FieldElement ctx) where
-  source = (: [])
 
 -- | Transform a step function into a recursive function
 recursiveFunction
@@ -101,7 +103,9 @@ recursiveFunction
      , KnownNat (d + 1)
      , KnownNat (k - 1)
      , KnownNat k
-     , FieldAssumptions a c
+     , Binary a
+     , IsRecursivePoint c
+     , BaseField (Context c) ~ a
      )
   => Hasher
   -> HomomorphicCommit (FieldElement (Context c)) c
@@ -109,15 +113,14 @@ recursiveFunction
   -> RecursiveFunction d k a i p c
 recursiveFunction hash hcommit func =
   let
-    restore0
-      :: (SymbolicData x, Empty (Payload x)) => Context x (Layout x) -> x
-    restore0 l = restore (l, empty)
+    restoreP :: Context c (RecursiveP d k i p c) -> RecursivePayload d k i p c
+    restoreP lp = restore (hmap fstP lp, witnessF $ hmap sndP lp)
 
     -- A helper function to derive the accumulator scheme
     func' :: RecursiveFunction d k a i p c
     func'
-      (restore0 -> (x, h :: FieldElement (Context c)))
-      ( restore0 ->
+      (restore . (, empty) -> (x, h :: FieldElement (Context c)))
+      (restoreP ->
           ( RecursivePayload u _ _ _ _
               :: RecursivePayload d k i p c
             )
@@ -129,13 +132,13 @@ recursiveFunction hash hcommit func =
     pRec = predicate func'
    in
     \i
-     ( restore0 ->
+     ( restoreP ->
          ( RecursivePayload u piX accX flag pf
              :: RecursivePayload d k i p c
            )
        ) ->
         let z = FieldElement <$> unpacked i
-            (x, _ :: FieldElement (Context c)) = restore0 i
+            (x, _ :: FieldElement (Context c)) = restore (i, empty)
             accX' = verifier (accumulatorScheme hash hcommit pRec) z piX accX pf
             h = bool zero (oracle hash accX') flag
          in arithmetize (func x u, h :: FieldElement (CircuitContext a))
@@ -152,6 +155,7 @@ recursivePredicate
      , LayoutFunctor i
      , LayoutFunctor p
      , SymbolicData c
+     , LayoutFunctor (Payload c)
      )
   => RecursiveFunction d k a i p c
   -> Predicate a (RecursiveI i) (RecursiveP d k i p c)

--- a/symbolic-base/src/ZkFold/Protocol/IVC/RecursiveFunction.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/RecursiveFunction.hs
@@ -38,12 +38,13 @@ type RecursiveI i = i :*: Par1
 newtype DataSource c = DataSource {dataSource :: c}
   deriving newtype
     ( AdditiveGroup
-    , AdditiveMonoid
+    , Zero
     , AdditiveSemigroup
     , CyclicGroup
     , SymbolicData
     )
 
+deriving newtype instance AdditiveMonoid c => AdditiveMonoid (DataSource c)
 deriving instance {-# INCOHERENT #-} Scale a c => Scale a (DataSource c)
 
 instance
@@ -55,15 +56,10 @@ instance
 -- | Payload to the recursive function
 data RecursivePayload d k i p c = RecursivePayload
   { recPayload :: Context c p
-  , recProof :: Vector k (DataSource c)
-  , recAccInst
-      :: AccumulatorInstance
-           k
-           (RecursiveI i)
-           (DataSource c)
-           (FieldElement (Context c))
+  , recProof :: Vector k c
+  , recAccInst :: AccumulatorInstance k (RecursiveI i) c (FieldElement (Context c))
   , recFlag :: Bool (Context c)
-  , recCommits :: Vector (d - 1) (DataSource c)
+  , recCommits :: Vector (d - 1) c
   }
   deriving Generic
 
@@ -90,6 +86,7 @@ type FieldAssumptions a c =
   , Empty (Payload c)
   , Scale (FieldElement (Context c)) c
   , AdditiveGroup c
+  , OracleSource (FieldElement (Context c)) c
   )
 
 instance OracleSource (FieldElement ctx) (FieldElement ctx) where
@@ -107,7 +104,7 @@ recursiveFunction
      , FieldAssumptions a c
      )
   => Hasher
-  -> HomomorphicCommit (FieldElement (Context c)) (DataSource c)
+  -> HomomorphicCommit (FieldElement (Context c)) c
   -> StepFunction a i p
   -> RecursiveFunction d k a i p c
 recursiveFunction hash hcommit func =

--- a/symbolic-base/src/ZkFold/Protocol/IVC/WeierstrassWitness.hs
+++ b/symbolic-base/src/ZkFold/Protocol/IVC/WeierstrassWitness.hs
@@ -13,16 +13,7 @@ import Data.String (fromString)
 import GHC.Generics (Generic, Par1 (..), U1 (..), unPar1)
 import Prelude (Integer, Traversable (traverse), error, fromInteger, type (~))
 
-import ZkFold.Algebra.Class (
-  AdditiveGroup (..),
-  AdditiveMonoid (..),
-  AdditiveSemigroup (..),
-  MultiplicativeMonoid (..),
-  Scale (..),
-  SemiEuclidean (..),
-  fromConstant,
-  (*),
- )
+import ZkFold.Algebra.Class
 import ZkFold.Algebra.EllipticCurve.BLS12_381 (BLS12_381_Base, BLS12_381_Scalar)
 import ZkFold.Algebra.EllipticCurve.Class (CyclicGroup (..), Planar, Point (..), Weierstrass (..), pointXY)
 import ZkFold.Algebra.Number (Natural, value)
@@ -123,17 +114,17 @@ instance
   WeierstrassWitness p1 + WeierstrassWitness p2 =
     WeierstrassWitness (p1 + p2)
 
+instance Symbolic ctx => Zero (WeierstrassWitness ctx) where
+  zero = WeierstrassWitness zero
+
 instance
   ( Symbolic ctx
   , Conditional b (IntegralOf (WitnessField ctx))
   , Conditional b (Weierstrass "BLS12-381-G1" (Point (ForeignField BLS12_381_Base (IntegralOf (WitnessField ctx)))))
-  , Conditional b b
   , b ~ BooleanOf (IntegralOf (WitnessField ctx))
   , Scale Natural (WeierstrassWitness ctx)
   )
   => AdditiveMonoid (WeierstrassWitness ctx)
-  where
-  zero = WeierstrassWitness zero
 
 instance
   ( Symbolic ctx

--- a/symbolic-base/src/ZkFold/Protocol/Plonkup/Relation.hs
+++ b/symbolic-base/src/ZkFold/Protocol/Plonkup/Relation.hs
@@ -135,8 +135,10 @@ instance Exponent a b => Exponent (Vector a) b where
 instance AdditiveSemigroup a => AdditiveSemigroup (Vector a) where
   (+) = zipLongest (+)
 
-instance AdditiveMonoid a => AdditiveMonoid (Vector a) where
+instance Zero a => Zero (Vector a) where
   zero = V.singleton zero
+
+instance AdditiveMonoid a => AdditiveMonoid (Vector a)
 
 instance AdditiveGroup a => AdditiveGroup (Vector a) where
   negate = fmap negate

--- a/symbolic-base/src/ZkFold/Symbolic/Data/FFA.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/FFA.hs
@@ -285,8 +285,10 @@ instance (Symbolic c, KnownFFA p r c) => AdditiveSemigroup (FFA p r c) where
 instance (Symbolic c, KnownFFA p r c, Scale a (Zp p)) => Scale a (FFA p r c) where
   scale k x = fromConstant (scale k one :: Zp p) * x
 
-instance (Symbolic c, KnownFFA p r c) => AdditiveMonoid (FFA p r c) where
+instance (Symbolic c, KnownFFA p r c) => Zero (FFA p r c) where
   zero = fromConstant (zero :: Zp p)
+
+instance (Symbolic c, KnownFFA p r c) => AdditiveMonoid (FFA p r c)
 
 instance (Symbolic c, KnownFFA p r c) => AdditiveGroup (FFA p r c) where
   -- \| negate cannot overflow if value is nonzero.

--- a/symbolic-base/src/ZkFold/Symbolic/Data/FieldElement.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/FieldElement.hs
@@ -84,8 +84,10 @@ instance Symbolic c => AdditiveSemigroup (FieldElement c) where
     fromCircuit2F x y $
       \(Par1 i) (Par1 j) -> Par1 <$> newAssigned (\w -> w i + w j)
 
-instance Symbolic c => AdditiveMonoid (FieldElement c) where
+instance Symbolic c => Zero (FieldElement c) where
   zero = FieldElement $ embed (Par1 zero)
+
+instance Symbolic c => AdditiveMonoid (FieldElement c)
 
 instance Symbolic c => AdditiveGroup (FieldElement c) where
   negate (FieldElement x) = FieldElement $ fromCircuitF x $ \(Par1 i) ->

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Int.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Int.hs
@@ -75,6 +75,8 @@ abs i = withNumberOfRegisters @n @r @(BaseField c) $ bool i (negate i) (isNegati
 
 deriving newtype instance (Symbolic c, KnownNat n, KnownRegisterSize r) => MultiplicativeMonoid (Int n r c)
 
+deriving newtype instance (Symbolic c, KnownNat n, KnownRegisterSize r) => Zero (Int n r c)
+
 deriving newtype instance (Symbolic c, KnownNat n, KnownRegisterSize r) => AdditiveMonoid (Int n r c)
 
 deriving newtype instance (Symbolic c, KnownNat n, KnownRegisterSize r) => Arbitrary (Int n r c)
@@ -209,14 +211,14 @@ instance
 
   x < y = y > x
 
-  i1 >= i2 = (isNotNegative i1 && isNegative i2) || (ub && (not $ xor (isNegative i1) (isNegative i2)))
+  i1 >= i2 = (isNotNegative i1 && isNegative i2) || (ub && not (xor (isNegative i1) (isNegative i2)))
    where
     ub =
       withGetRegisterSize @n @r @(BaseField c) $
         withCeilRegSize @(GetRegisterSize (BaseField c) n r) @OrdWord $
           uint i1 >= uint i2
 
-  i1 > i2 = (isNotNegative i1 && isNegative i2) || (ub && (not $ xor (isNegative i1) (isNegative i2)))
+  i1 > i2 = (isNotNegative i1 && isNegative i2) || (ub && not (xor (isNegative i1) (isNegative i2)))
    where
     ub =
       withGetRegisterSize @n @r @(BaseField c) $

--- a/symbolic-base/src/ZkFold/Symbolic/Data/UInt.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/UInt.hs
@@ -37,7 +37,7 @@ import Data.Function (on)
 import Data.Functor (Functor (..), (<$>))
 import Data.Functor.Rep (Representable (..))
 import Data.Kind (Type)
-import Data.List (unfoldr, zip, iterate)
+import Data.List (iterate, unfoldr, zip)
 import Data.Map (fromList, (!))
 import Data.Maybe (fromJust)
 import Data.Traversable (for, traverse)
@@ -574,7 +574,6 @@ instance (Symbolic c, KnownNat n, KnownRegisterSize r) => AdditiveSemigroup (UIn
                 (ks, _) <- splitExpansion (highRegisterSize @(BaseField c) @n @r) 1 k
                 return $ V.unsafeToVector (zs ++ [ks])
             )
-
 
 instance (Symbolic c, KnownNat n, KnownRegisterSize r) => Zero (UInt n r c) where
   zero = fromConstant (0 :: Natural)

--- a/symbolic-base/src/ZkFold/Symbolic/Data/Vec.hs
+++ b/symbolic-base/src/ZkFold/Symbolic/Data/Vec.hs
@@ -83,11 +83,10 @@ instance
   where
   one = fromConstant (1 :: Natural)
 
-instance
-  (Symbolic c, Traversable f, Representable f)
-  => AdditiveMonoid (Vec f c)
-  where
+instance (Symbolic c, Representable f) => Zero (Vec f c) where
   zero = fromConstant (0 :: Natural)
+
+instance (Symbolic c, Traversable f, Representable f) => AdditiveMonoid (Vec f c)
 
 instance
   (Symbolic c, Traversable f, Representable f)

--- a/symbolic-base/test/Tests/Protocol/IVC.hs
+++ b/symbolic-base/test/Tests/Protocol/IVC.hs
@@ -4,7 +4,6 @@ module Tests.Protocol.IVC where
 
 import Control.Lens ((^.))
 import Data.Bifunctor (bimap, first)
-import Data.Foldable (toList)
 import GHC.Generics (U1 (..))
 import Test.Hspec (Spec, describe, it)
 import Test.QuickCheck (property, withMaxSuccess)
@@ -47,6 +46,7 @@ import ZkFold.Protocol.IVC.WeierstrassWitness (WeierstrassWitness (..))
 import ZkFold.Symbolic.Class (Symbolic (..))
 import ZkFold.Symbolic.Data.FieldElement (FieldElement (..))
 import ZkFold.Symbolic.Interpreter (Interpreter (..))
+import Data.Function (on)
 
 type A = Zp BLS12_381_Scalar
 
@@ -171,7 +171,7 @@ specIVC = do
     describe "verifier" $ do
       it "must output zeros on the public input and message" $ do
         withMaxSuccess 10 $ property $ \p ->
-          (\(a, b) -> all ((== zero) . dataSource) (toList a) && all (== zero) b) $
+          (\(a, b) -> all (uncurry ((==) `on` dataSource)) a && all (== zero) b) $
             FS.verifier (sps p) (pi p) (zip (ms p) (cs p)) (unsafeToVector [])
   describe "Accumulator scheme specification" $ do
     describe "decider" $ do

--- a/symbolic-base/test/Tests/Protocol/IVC.hs
+++ b/symbolic-base/test/Tests/Protocol/IVC.hs
@@ -25,7 +25,7 @@ import ZkFold.Protocol.IVC.Accumulator (
   x,
  )
 import ZkFold.Protocol.IVC.AccumulatorScheme as Acc
-import ZkFold.Protocol.IVC.Commit (hcommit)
+import ZkFold.Protocol.IVC.Commit (cyclicCommit)
 import ZkFold.Protocol.IVC.CommitOpen (commitOpen)
 import ZkFold.Protocol.IVC.FiatShamir (FiatShamir, fiatShamir)
 import qualified ZkFold.Protocol.IVC.FiatShamir as FS
@@ -111,7 +111,7 @@ specIVC = do
       -- sps0Rec = specialSoundProtocolI @D . phiRec
 
       sps :: PAR -> SPS
-      sps = fiatShamir mimcHash . commitOpen . sps0
+      sps = fiatShamir mimcHash . commitOpen cyclicCommit . sps0
 
       -- spsRec :: PAR -> SPSRec
       -- spsRec = fiatShamir mimcHash . commitOpen . sps0Rec
@@ -138,10 +138,10 @@ specIVC = do
       ms p = let NARKInstanceProof _ (NARKProof _ z) = narkIP p in z
 
       scheme :: PAR -> AccumulatorScheme D 1 I (DataSource C) F
-      scheme = accumulatorScheme mimcHash . phi
+      scheme = accumulatorScheme mimcHash cyclicCommit . phi
 
       acc0 :: PAR -> Accumulator K I (DataSource C) F
-      acc0 = emptyAccumulator @D . phi
+      acc0 = emptyAccumulator @D cyclicCommit . phi
 
       -- acc0Rec :: PAR -> Accumulator K (RecursiveI I) (DataSource C) F
       -- acc0Rec = emptyAccumulator @D . phiRec
@@ -155,7 +155,8 @@ specIVC = do
   describe "WeierstrassWitness" $ do
     it "is a homomorphic commitment" $ do
       withMaxSuccess 10 $ property $ \(fromConstant @Integer -> p) (fromConstant @Integer -> q) ->
-        hcommit @(WeierstrassWitness (Interpreter A)) [p + q] == hcommit [p] + hcommit [q]
+        cyclicCommit @(WeierstrassWitness (Interpreter A)) [p + q]
+        == cyclicCommit [p] + cyclicCommit [q]
   describe "Special sound protocol specification" $ do
     describe "verifier" $ do
       it "must output zeros on the public input and message" $ do

--- a/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/Value.hs
+++ b/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/Value.hs
@@ -76,4 +76,4 @@ instance
 instance Zero (Value n context) where
   zero = Value $ unsafeToVector []
 
-instance (Haskell.Ord (PolicyId context), Haskell.Ord (AssetName context), Symbolic context) => AdditiveMonoid (Value n context) where
+instance (Haskell.Ord (PolicyId context), Haskell.Ord (AssetName context), Symbolic context) => AdditiveMonoid (Value n context)

--- a/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/Value.hs
+++ b/symbolic-cardano/src/ZkFold/Symbolic/Cardano/Types/Value.hs
@@ -65,7 +65,7 @@ instance (Haskell.Ord (PolicyId context), Haskell.Ord (AssetName context), Symbo
   (<>) (Value va) (Value vb) = Value $ unsafeToVector $ Map.toList $ Map.unionWith (+) (Map.fromList (fromVector va)) (Map.fromList (fromVector vb))
 
 instance (Haskell.Ord (PolicyId context), Haskell.Ord (AssetName context), Symbolic context) => Monoid (Value n context) where
-  mempty = Value $ unsafeToVector []
+  mempty = zero
 
 instance
   (Haskell.Ord (PolicyId context), Haskell.Ord (AssetName context), Symbolic context)
@@ -73,5 +73,7 @@ instance
   where
   (+) = (<>)
 
+instance Zero (Value n context) where
+  zero = Value $ unsafeToVector []
+
 instance (Haskell.Ord (PolicyId context), Haskell.Ord (AssetName context), Symbolic context) => AdditiveMonoid (Value n context) where
-  zero = mempty

--- a/symbolic-uplc/src/ZkFold/Symbolic/UPLC/Class.hs
+++ b/symbolic-uplc/src/ZkFold/Symbolic/UPLC/Class.hs
@@ -114,6 +114,8 @@ deriving newtype instance (Sym c, FromConstant k (FFA BLS12_381_Scalar Auto c)) 
 
 deriving newtype instance Sym c => AdditiveSemigroup (BLS12_381_G2_Point c)
 
+deriving newtype instance Sym c => Zero (BLS12_381_G2_Point c)
+
 deriving newtype instance Sym c => AdditiveMonoid (BLS12_381_G2_Point c)
 
 deriving newtype instance Sym c => AdditiveGroup (BLS12_381_G2_Point c)


### PR DESCRIPTION
* strengthened `HomomorphicCommit` to be an additive action rather than just a function on curve points;
* split commitment type into `pt` type which is an additive group and a `c` type which can be additively acted upon by `pt`.
* made `OperationRecord` to store a proper list of operations to check